### PR TITLE
Use FOS fork of oauth2 lib

### DIFF
--- a/vendor/vendors.php
+++ b/vendor/vendors.php
@@ -24,7 +24,7 @@ $deps = array(
     array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/master'),
     array('doctrine-mongodb-odm', 'http://github.com/doctrine/mongodb-odm.git', 'origin/master'),
     array('doctrine-mongodb', 'http://github.com/doctrine/mongodb.git', 'origin/master'),
-    array('oauth2-php', 'https://github.com/arnaud-lb/oauth2-php', 'origin/master'),
+    array('oauth2-php', 'https://github.com/FriendsOfSymfony/oauth2-php.git', 'origin/master'),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
Bundle is developed along with FOS fork of oauth2 lib, so this one should be used when running tests.
