### PR TITLE
Added missing parameter declaration for ODM

### DIFF
--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="fos_oauth_server.model.client.manager.class">FOS\OAuthServerBundle\Document\ClientManager</parameter>
         <parameter key="fos_oauth_server.model.access.token.manager.class">FOS\OAuthServerBundle\Document\AccessTokenManager</parameter>
+        <parameter key="fos_oauth_server.model.refresh.token.manager.class">FOS\OAuthServerBundle\Document\RefreshTokenManager</parameter>
         <parameter key="fos_oauth_server.model.auth.code.manager.class">FOS\OAuthServerBundle\Document\AuthCodeManager</parameter>
     </parameters>
 


### PR DESCRIPTION
RefreshTokenManager declaration is required and missing from `odm.xml`.

Introduced in #17
