### PR TITLE
Added missing methods from `ManagerInterface` classes for ODM

### DIFF
--- a/Document/AuthCodeManager.php
+++ b/Document/AuthCodeManager.php
@@ -64,4 +64,18 @@ class AuthCodeManager extends BaseAuthCodeManager
         $this->dm->remove($authCode);
         $this->dm->flush();
     }
+
+    /**
+     * @return boolean
+     */
+    public function deleteExpired()
+    {
+        return $this
+            ->repository
+            ->createQueryBuilder()
+            ->findAndRemove()
+            ->field('expiresAt')->lt(time())
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/Document/TokenManager.php
+++ b/Document/TokenManager.php
@@ -54,4 +54,18 @@ class TokenManager extends BaseTokenManager
         $this->dm->remove($token);
         $this->dm->flush();
     }
+
+    /**
+     * @return boolean
+     */
+    public function deleteExpired()
+    {
+        return $this
+            ->repository
+            ->createQueryBuilder()
+            ->findAndRemove()
+            ->field('expiresAt')->lt(time())
+            ->getQuery()
+            ->execute();
+    }
 }


### PR DESCRIPTION
Method `deleteExpired()` is defined in `AuthCodeManagerInterface` and `TokenManagerInterface` but not implemented in the ODM-flavored managers.
