### PR TITLE
getRedirectUris() method already declared in IOAuth2Client

### DIFF
--- a/Model/ClientInterface.php
+++ b/Model/ClientInterface.php
@@ -29,8 +29,6 @@ interface ClientInterface extends IOAuth2Client
 
     function setRedirectUris(array $redirectUris);
 
-    function getRedirectUris();
-
     function setAllowedGrantTypes(array $grantTypes);
 
     function getAllowedGrantTypes();


### PR DESCRIPTION
php 5.3.2

Fatal error: Can't inherit abstract function OAuth2\Model\IOAuth2Client::getRedirectUris() (previously declared abstract in FOS\OAuthServerBundle\Model\ClientInterface) in /var/www/nde/vendor/bundles/FOS/OAuthServerBundle/Model/ClientInterface.php on line 17
