### PR TITLE
Fixes session security issue

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -46,6 +46,11 @@ class AuthorizeController extends ContainerAware
             throw new AccessDeniedException('This user does not have access to this section.');
         }
 
+        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
+            $this->container->get('session')->invalidate(600);
+            $this->container->get('session')->set('_fos_oauth_server.ensure_logout', true);
+        }
+
         $form = $this->container->get('fos_oauth_server.authorize.form');
         $formHandler = $this->container->get('fos_oauth_server.authorize.form.handler');
 
@@ -84,6 +89,7 @@ class AuthorizeController extends ContainerAware
     protected function processSuccess(UserInterface $user, AuthorizeFormHandler $formHandler)
     {
         if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
+            $this->container->get('security.context')->setToken(null);
             $this->container->get('session')->invalidate();
         }
 


### PR DESCRIPTION
According to the Session documentation, the invalidate method expect one parameter _($lifetime, integer)_

> Sets the cookie lifetime for the session cookie. A null value will leave the system settings unchanged, 0 sets the cookie to expire with browser session. Time is in seconds, and is not a Unix timestamp.

With the current implementation, calling `->invalidate()` will keep the session alive until the browser is closed. Even if the /authorize action is a redirection, a malicious user could exploit this breach.

The fixe will reduce the open window to 1 second after issuing the authorization code (minimum allowed by the invalidate method)
