### PR TITLE
Fix error when using token endpoint with grant_type=client_credentials

### DIFF
--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -111,9 +111,13 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
         $token = $this->accessTokenManager->createToken();
         $token->setToken($tokenString);
         $token->setClient($client);
-        $token->setUser($data);
         $token->setExpiresAt($expires);
         $token->setScope($scope);
+
+        if (null !== $data) {
+            $token->setUser($data);
+        }
+
         $this->accessTokenManager->updateToken($token);
 
         return $token;
@@ -202,9 +206,13 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
         $token = $this->refreshTokenManager->createToken();
         $token->setToken($tokenString);
         $token->setClient($client);
-        $token->setUser($data);
         $token->setExpiresAt($expires);
         $token->setScope($scope);
+
+        if (null !== $data) {
+            $token->setUser($data);
+        }
+
         $this->refreshTokenManager->updateToken($token);
 
         return $token;

--- a/Tests/Storage/OAuthStorageTest.php
+++ b/Tests/Storage/OAuthStorageTest.php
@@ -155,6 +155,28 @@ class OAuthStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo bar', $token->getScope());
     }
 
+    public function testCreateAccessTokenWithoutUser()
+    {
+        $savedToken = null;
+
+        $this->accessTokenManager->expects($this->once())
+            ->method('createToken')
+            ->with()
+            ->will($this->returnValue(new AccessToken));
+        $this->accessTokenManager->expects($this->once())
+            ->method('updateToken')
+            ->will($this->returnCallback(function($token) use (&$savedToken) {
+            $savedToken = $token;
+        }));
+
+        $client = new Client();
+        $user   = null;
+
+        $token = $this->storage->createAccessToken('foo', $client, $user, 1, 'foo bar');
+
+        $this->assertEquals($token, $savedToken);
+    }
+
     public function testGetRefreshTokenReturnsRefreshTokenWithGivenId()
     {
         $token = new RefreshToken();
@@ -212,6 +234,28 @@ class OAuthStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($user, $token->getUser());
         $this->assertSame(1, $token->getExpiresAt());
         $this->assertSame('foo bar', $token->getScope());
+    }
+
+    public function testCreateRefreshTokenWithoutUser()
+    {
+        $savedToken = null;
+
+        $this->refreshTokenManager->expects($this->once())
+            ->method('createToken')
+            ->with()
+            ->will($this->returnValue(new RefreshToken));
+        $this->refreshTokenManager->expects($this->once())
+            ->method('updateToken')
+            ->will($this->returnCallback(function($token) use (&$savedToken) {
+            $savedToken = $token;
+        }));
+
+        $client = new Client();
+        $user   = null;
+
+        $token = $this->storage->createRefreshToken('foo', $client, $user, 1, 'foo bar');
+
+        $this->assertEquals($token, $savedToken);
     }
 
     public function testCheckRestrictedGrantTypeThrowsOnInvalidClientClass()


### PR DESCRIPTION
Hey guys,

I was trying the client_credentials grant_type, but i ran into errors.
`FOS\OAuthServerBundle\Storage\OAuthStorage::createAccessToken` throws an exception with $data=null ($data is the user).
Same thing happens to `FOS\OAuthServerBundle\Storage\OAuthStorage::createRefreshToken`

Below the errors with the tests i added and without the fixes.

```
There were 2 errors:

1) FOS\OAuth2ServiceBundle\Tests\Storage\OAuthStorageTest::testCreateAccessTokenWithoutUser
InvalidArgumentException: Client has to implement the ClientInterface

FOSOAuthServerBundle/Storage/OAuthStorage.php:108
FOSOAuthServerBundle/Tests/Storage/OAuthStorageTest.php:133

2) FOS\OAuth2ServiceBundle\Tests\Storage\OAuthStorageTest::testCreateRefreshTokenWithoutUser
Argument 1 passed to FOS\OAuthServerBundle\Model\Token::setUser() must implement interface Symfony\Component\Security\Core\User\UserInterface, null given, called in FOSOAuthServerBundle/Storage/OAuthStorage.php on line 205 and defined

FOSOAuthServerBundle/Model/Token.php:136
FOSOAuthServerBundle/Storage/OAuthStorage.php:205
FOSOAuthServerBundle/Tests/Storage/OAuthStorageTest.php:242
```

This solution works for now well for me, and did not break existing tests.
I fixed the errors by the path that seemed obvious to me, feedback appreciated!
