### PR TITLE
Update oauth2-php to dev-master version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "friendsofsymfony/oauth2-php": "1.0.*",
+        "friendsofsymfony/oauth2-php": "*",
         "symfony/framework-bundle": "2.1.*",
         "symfony/security-bundle": "2.1.*"
     },


### PR DESCRIPTION
There is no incompatibilities with dev-master version, why restricting it ?
