### PR TITLE
Update services to allow class overriding

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -4,19 +4,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="fos_oauth_server.security.authentication.provider.class">FOS\OAuthServerBundle\Security\Authentication\Provider\OAuthProvider</parameter>
+        <parameter key="fos_oauth_server.security.authentication.listener.class">FOS\OAuthServerBundle\Security\Firewall\OAuthListener</parameter>
+        <parameter key="fos_oauth_server.security.entry_point.class">FOS\OAuthServerBundle\Security\EntryPoint\OAuthEntryPoint</parameter>
+    </parameters>
+    
     <services>
-        <service id="fos_oauth_server.security.authentication.provider" class="FOS\OAuthServerBundle\Security\Authentication\Provider\OAuthProvider" public="false">
+        <service id="fos_oauth_server.security.authentication.provider" class="%fos_oauth_server.security.authentication.provider.class%" public="false">
             <argument /> <!-- user provider -->
             <argument type="service" id="fos_oauth_server.server" />
         </service>
 
-        <service id="fos_oauth_server.security.authentication.listener" class="FOS\OAuthServerBundle\Security\Firewall\OAuthListener" public="false">
+        <service id="fos_oauth_server.security.authentication.listener" class="%fos_oauth_server.security.authentication.listener.class%" public="false">
             <argument type="service" id="security.context"/>
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="fos_oauth_server.server" />
         </service>
 
-        <service id="fos_oauth_server.security.entry_point" class="FOS\OAuthServerBundle\Security\EntryPoint\OAuthEntryPoint" public="false">
+        <service id="fos_oauth_server.security.entry_point" class="%fos_oauth_server.security.entry_point.class%" public="false">
             <argument type="service" id="fos_oauth_server.server" />
         </service>
     </services>


### PR DESCRIPTION
Due to scope delimiter limitation, it can be useful to be able to override OAuthProvider::authenticate, which explode scope to assign roles to user, to update scope delimiter and use build-in ROLE management.
