### PR TITLE
fix propel default allowed_grand_types array

### DIFF
--- a/Propel/Client.php
+++ b/Propel/Client.php
@@ -21,19 +21,24 @@ class Client extends BaseClient implements ClientInterface
     public function __construct()
     {
         parent::__construct();
-
-        $this->setAllowedGrantTypes(array(
-            OAuth2::GRANT_TYPE_AUTH_CODE,
-        ));
         $this->setRandomId(Random::generateToken());
         $this->setSecret(Random::generateToken());
     }
+
+    public function hydrate($row, $startcol = 0, $rehydrate = false)
+    {
+        parent::hydrate($row, $startcol, $rehydrate);
+
+        $this->setAllowedGrantTypes($this->getAllowedGrantTypes() + array(OAuth2::GRANT_TYPE_AUTH_CODE));
+    }
+
 
     /**
      * {@inheritdoc}
      */
     public function checkSecret($secret)
     {
+
         return (null === $this->secret || $secret === $this->secret);
     }
 


### PR DESCRIPTION
Propel allowed_grand_types never comes from the db, because of early overriding
