### PR TITLE
Added user_provider argument to the storage service

### DIFF
--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -43,6 +43,7 @@ class FOSOAuthServerExtension extends Extension
         $container->setAlias('fos_oauth_server.refresh_token_manager', $config['service']['refresh_token_manager']);
         $container->setAlias('fos_oauth_server.auth_code_manager', $config['service']['auth_code_manager']);
 
+        $container->setAlias('fos_oauth_server.user_provider', $config['service']['user_provider']);
         $container->setParameter('fos_oauth_server.server.options', $config['service']['options']);
 
         $this->remapParametersNamespaces($config, $container, array(

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="fos_oauth_server.access_token_manager" />
             <argument type="service" id="fos_oauth_server.refresh_token_manager" />
             <argument type="service" id="fos_oauth_server.auth_code_manager" />
-            <argument>null</argument>
+            <argument type="service" id="fos_oauth_server.user_provider" />
             <argument type="service" id="security.encoder_factory" />
         </service>
 


### PR DESCRIPTION
For the "Resource Owner Credentials" (password) grant type, a user_provider must be added in order to load a user entity from the given credentials.

Currently, the user_provider is not enabled (set hardcoded to null) in the OAuthStorage service so the system will fail in the FOS\OAuthServerBundle\Storage\OAuthStorage::checkUserCredentials (around line 131).

This is patch #72, based on the 1.1.x branch
