### PR TITLE
Fix: Clean cmd Exception when using MongoDB Docs

### DIFF
--- a/Document/AuthCodeManager.php
+++ b/Document/AuthCodeManager.php
@@ -78,12 +78,14 @@ class AuthCodeManager extends BaseAuthCodeManager
      */
     public function deleteExpired()
     {
-        return $this
+        $result = $this
             ->repository
             ->createQueryBuilder()
-            ->findAndRemove()
+            ->remove()
             ->field('expiresAt')->lt(time())
-            ->getQuery()
+            ->getQuery(array('safe' => true))
             ->execute();
+
+        return $result['n'];
     }
 }

--- a/Document/TokenManager.php
+++ b/Document/TokenManager.php
@@ -79,12 +79,14 @@ class TokenManager extends BaseTokenManager
      */
     public function deleteExpired()
     {
-        return $this
+        $result = $this
             ->repository
             ->createQueryBuilder()
-            ->findAndRemove()
+            ->remove()
             ->field('expiresAt')->lt(time())
-            ->getQuery()
+            ->getQuery(array('safe' => true))
             ->execute();
+
+        return $result['n'];
     }
 }


### PR DESCRIPTION
When using the clean command with MongoDB Documents.
The command throws an exception

```
[ErrorException]                                                                                                                                                                                                                               
  Notice: Object of class Acme\AcmeBundle\Document\AccessToken could not be converted to int in [..]/vendor/friendsofsymfony/oauth-server-bundle/FOS/OAuthServerBundle/Command/CleanCommand.php line 54
```

findAndRemove() method returns the object, and delete it from the database.
I expected the method to return a Collection, but it returns only the first object that match the "expired" criteria.
When the exception is raised only one Document has been deleted from the database.

This PR is maybe not the perfect solution as remove() does not return a collection or an iterator, the query will just return a boolean.

so the result in the console is like this:

```
$ php app/console fos:oauth-server:clean
Removed 1 items from Access token storage.
Removed 1 items from Refresh token storage.
Removed 1 items from Auth code storage.
```

I didn't want to code two queries, (one to get all the expired tokens / code) then one other to delete them just to return the correct amount of documents because those collections may be potentially huge. (But maybe an expert of Doctrine ODM Query optimization can improve the code to make it perfect).
