### PR TITLE
mongo mapping fix

### DIFF
--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -6,8 +6,8 @@
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\Client">
         <field name="randomId" fieldName="randomId" type="string" />
-        <field name="redirectUris" fieldName="redirectUris" type="hash" />
+        <field name="redirectUris" fieldName="redirectUris" type="collection" />
         <field name="secret" fieldName="secret" type="string" />
-        <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="hash" />
+        <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="collection" />
     </mapped-superclass>
 </doctrine-mongo-mapping>


### PR DESCRIPTION
The hash type is for storing associative arrays, the collection type is for storing indexed arrays.
