### PR TITLE
Use UserProvider if user is not instance of UserInteface

### DIFF
--- a/Security/Authentication/Provider/OAuthProvider.php
+++ b/Security/Authentication/Provider/OAuthProvider.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
@@ -61,6 +62,10 @@ class OAuthProvider implements AuthenticationProviderInterface
             if ($accessToken = $this->serverService->verifyAccessToken($tokenString)) {
                 $scope = $accessToken->getScope();
                 $user  = $accessToken->getUser();
+
+                if (!$user instanceof UserInterface) {
+                    $user = $this->userProvider->loadUserByUsername($user);
+                }
 
                 $roles = (null !== $user) ? $user->getRoles() : array();
 

--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -16,6 +16,7 @@ use FOS\OAuthServerBundle\Model\RefreshTokenManagerInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManagerInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use FOS\OAuthServerBundle\Model\ClientInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -134,6 +135,9 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
         $token->setScope($scope);
 
         if (null !== $data) {
+            if (!$data instanceof UserInterface) {
+                $data = $this->userProvider->loadUserByUsername($data);
+            }
             $token->setUser($data);
         }
 
@@ -229,6 +233,9 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
         $token->setScope($scope);
 
         if (null !== $data) {
+            if (!$data instanceof UserInterface) {
+                $data = $this->userProvider->loadUserByUsername($data);
+            }
             $token->setUser($data);
         }
 


### PR DESCRIPTION
Hi,

This patch makes use of the UserProvider if the User is not an instance of UserInteface.

For exemple, it happens if you use the orm db_driver for the OAuth token/client/code but not for your users (so they are not properly hydrated).
