### PR TITLE
Check AdvancedUserInterface flags at password grant

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="fos_oauth_server.auth_code_manager" />
             <argument>null</argument>
             <argument type="service" id="security.encoder_factory" />
+            <argument type="service" id="security.user_checker" />
         </service>
 
         <service id="fos_oauth_server.server" class="%fos_oauth_server.server.class%">

--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -17,6 +17,7 @@ use FOS\OAuthServerBundle\Model\AuthCodeManagerInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use OAuth2\OAuth2;
@@ -63,6 +64,11 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
     protected $encoderFactory;
 
     /**
+     * @var \Symfony\Component\Security\Core\User\UserCheckerInterface
+     */
+    protected $userChecker;
+
+    /**
      * @var array [uri] => GrantExtensionInterface
      */
     protected $grantExtensions;
@@ -74,10 +80,12 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
      * @param \FOS\OAuthServerBundle\Model\AuthCodeManagerInterface $authCodeManager
      * @param null|\Symfony\Component\Security\Core\User\UserProviderInterface $userProvider
      * @param null|\Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface $encoderFactory
+     * @param \Symfony\Component\Security\Core\User\UserCheckerInterface $userChecker
      */
     public function __construct(ClientManagerInterface $clientManager, AccessTokenManagerInterface $accessTokenManager,
         RefreshTokenManagerInterface $refreshTokenManager, AuthCodeManagerInterface $authCodeManager,
-        UserProviderInterface $userProvider = null, EncoderFactoryInterface $encoderFactory = null)
+        UserProviderInterface $userProvider = null, EncoderFactoryInterface $encoderFactory = null,
+        UserCheckerInterface $userChecker)
     {
         $this->clientManager = $clientManager;
         $this->accessTokenManager = $accessTokenManager;
@@ -85,6 +93,7 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
         $this->authCodeManager = $authCodeManager;
         $this->userProvider = $userProvider;
         $this->encoderFactory = $encoderFactory;
+        $this->userChecker = $userChecker;
 
         $this->grantExtensions = array();
     }
@@ -159,6 +168,7 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
 
         try {
             $user = $this->userProvider->loadUserByUsername($username);
+            $this->userChecker->checkPostAuth($user);
         } catch(AuthenticationException $e) {
             return false;
         }


### PR DESCRIPTION
Fix #148

It's two things:
1. The verbose is really poor. The user can't know if the problem is the password or if he's locked, disabled... It will be necessary modify oauth2-php.
2. The constructor has a non-default argument rightmost default one. I try to fix this with the commit f2761ae306959b87551c29fb3c30710cce255cc6 [(at this branch)](https://github.com/BraisGabin/FOSOAuthServerBundle/tree/refactor) but I have an error and I don't know how to fix it:

> Catchable Fatal Error: Argument 5 passed to FOS\OAuthServerBundle\Storage\OAuthStorage::__construct() must implement interface Symfony\Component\Security\Core\User\UserCheckerInterface, instance of FOS\UserBundle\Doctrine\UserManager given, called in [...]/app/cache/dev/appDevDebugProjectContainer.php on line 1254 and defined in [...]/vendor/friendsofsymfony/oauth-server-bundle/FOS/OAuthServerBundle/Storage/OAuthStorage.php line 87
