### PR TITLE
RE: Fix #150 Application authorization fails - no client id supplied

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -98,6 +98,10 @@ class AuthorizeController extends ContainerAware
             new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
         );
 
+        if (!$request->query->all() && $request->request->has('fos_oauth_server_authorize_form')) {
+            $request->query->add($request->request->get('fos_oauth_server_authorize_form'));
+        }
+
         try {
             return $this->container
                 ->get('fos_oauth_server.server')


### PR DESCRIPTION
Add fos_oauth_server_authorize_form parameters to the REQUEST on the GET to be validated by 'fos_oauth_server.server'
