### PR TITLE
Auth Code single use

### DIFF
--- a/Model/AuthCode.php
+++ b/Model/AuthCode.php
@@ -22,6 +22,11 @@ class AuthCode extends Token implements AuthCodeInterface
     protected $redirectUri;
 
     /**
+     * @var boolean
+     */
+    protected $used;
+
+    /**
      * {@inheritdoc}
      */
     public function setRedirectUri($redirectUri)
@@ -35,5 +40,21 @@ class AuthCode extends Token implements AuthCodeInterface
     public function getRedirectUri()
     {
         return $this->redirectUri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUsed($used)
+    {
+        $this->used = $used;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isUsed()
+    {
+        return $this->used;
     }
 }

--- a/Model/AuthCodeInterface.php
+++ b/Model/AuthCodeInterface.php
@@ -22,4 +22,9 @@ interface AuthCodeInterface extends TokenInterface, IOAuth2AuthCode
      * @param string $redirectUri
      */
     function setRedirectUri($redirectUri);
+
+    /**
+     * @param boolean $used
+     */
+    function setUsed($used);
 }


### PR DESCRIPTION
RFC 6749 indicates that an authorization code must be used only once to issue an access token.
This PR and PR at https://github.com/FriendsOfSymfony/oauth2-php/pull/36 simply add this restriction.

Fix #143
