### PR TITLE
Add unique constraints on token fields for Doctrine ORM

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -140,6 +140,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"token"})})
  */
 class AccessToken extends BaseAccessToken
 {
@@ -174,6 +175,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"token"})})
  */
 class RefreshToken extends BaseRefreshToken
 {
@@ -208,6 +210,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"token"})})
  */
 class AuthCode extends BaseAuthCode
 {


### PR DESCRIPTION
Add them to the examples in the documentation since unique constraints can only be added on concrete classes.

No index is added on the client table since the only query on the table is by `id` and `randomId`, where the primary key will be used.

This fixes #122.
