### PR TITLE
Use EntityManagerInterface to allow simple injection of mocked decorator classes

### DIFF
--- a/Entity/AuthCodeManager.php
+++ b/Entity/AuthCodeManager.php
@@ -12,6 +12,7 @@
 namespace FOS\OAuthServerBundle\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManager as BaseAuthCodeManager;
 

--- a/Entity/AuthCodeManager.php
+++ b/Entity/AuthCodeManager.php
@@ -36,7 +36,7 @@ class AuthCodeManager extends BaseAuthCodeManager
      * @param \Doctrine\ORM\EntityManager $em
      * @param string $class
      */
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManagerInterface $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);

--- a/Entity/ClientManager.php
+++ b/Entity/ClientManager.php
@@ -12,6 +12,7 @@
 namespace FOS\OAuthServerBundle\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManager as BaseClientManager;
 
@@ -32,7 +33,7 @@ class ClientManager extends BaseClientManager
      */
     protected $class;
 
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManagerInterface $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);

--- a/Entity/TokenManager.php
+++ b/Entity/TokenManager.php
@@ -12,6 +12,7 @@
 namespace FOS\OAuthServerBundle\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\OAuthServerBundle\Model\TokenInterface;
 use FOS\OAuthServerBundle\Model\TokenManager as BaseTokenManager;
 
@@ -32,7 +33,7 @@ class TokenManager extends BaseTokenManager
      */
     protected $class;
 
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManagerInterface $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);


### PR DESCRIPTION
I'm currently writing unit tests for controllers that are protected by an OAuth firewall. I mocked the client's entity manager using the `Doctrine\ORM\Decorator\EntityManagerDecorator` helper class. Unfortunately that class derives from `ObjectManager` in the class hierarchy. Changing the constructor signature to accept an `EntityManagerInterface` that's implemented by each and every Doctrine\ORM\EntityManager is helping out since I can use my EntityManagerDecorators to mock and test entity serialization. The reason why this affects the OAuthBundle is that the firewall depends on a valid instance of an EntityManager. I can't mock a complete EntityManager (returning user objects and tokens) so easily so I'm using a best-of-both-worlds approach: decorate the Entitymanager and mock its `persist` method -> OAuth classes work as expected (when no data is written), my Entities are persisted through overridden methods. 