### PR TITLE
Ensure user is logged out when client is authorized by pre-authorization event

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -60,6 +60,8 @@ class AuthorizeController extends ContainerAware
         );
 
         if ($event->isAuthorizedClient()) {
+            $this->invalidateSession();
+
             $scope = $this->container->get('request')->get('scope', null);
 
             return $this->container
@@ -88,10 +90,7 @@ class AuthorizeController extends ContainerAware
      */
     protected function processSuccess(UserInterface $user, AuthorizeFormHandler $formHandler, Request $request)
     {
-        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
-            $this->container->get('security.context')->setToken(null);
-            $this->container->get('session')->invalidate();
-        }
+        $this->invalidateSession();
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
@@ -147,5 +146,16 @@ class AuthorizeController extends ContainerAware
         }
 
         return $this->client;
+    }
+
+    /**
+     * @return void
+     */
+    protected function invalidateSession()
+    {
+        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
+            $this->container->get('security.context')->setToken(null);
+            $this->container->get('session')->invalidate();
+        }
     }
 }


### PR DESCRIPTION
When the pre-authorization event authorizes a client, the code that logs the user out is skipped.

This patch ensures the user is logged out in the above situation as well.
