### PR TITLE
Only invalidate session after 600 seconds when authorize form is displayed

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -46,11 +46,6 @@ class AuthorizeController extends ContainerAware
             throw new AccessDeniedException('This user does not have access to this section.');
         }
 
-        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
-            $this->container->get('session')->invalidate(600);
-            $this->container->get('session')->set('_fos_oauth_server.ensure_logout', true);
-        }
-
         $form = $this->container->get('fos_oauth_server.authorize.form');
         $formHandler = $this->container->get('fos_oauth_server.authorize.form.handler');
 
@@ -69,6 +64,11 @@ class AuthorizeController extends ContainerAware
 
         if (true === $formHandler->process()) {
             return $this->processSuccess($user, $formHandler, $request);
+        }
+
+        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
+            $this->container->get('session')->invalidate(600);
+            $this->container->get('session')->set('_fos_oauth_server.ensure_logout', true);
         }
 
         return $this->container->get('templating')->renderResponse(


### PR DESCRIPTION
Currently, if `_fos_oauth_server.ensure_logout` is set in the session, the session will be set to invalidate after 600 seconds by changing the cookie lifetime. When the authorize form is submitted or an event indicates the client is authorized, the current session is invalidated immediately.

The delayed invalidation sets the cookie lifetime of the current request to 600, which means all subsequent invalidations will also create a new session with lifetime of 600 seconds. So that if the client is authorized, the new session generated will have a lifetime of 600 seconds instead of the default value.

I have a situation that a web-based oauth client lives in the same domain name as the server. Even if the client and the server uses different firewall, the session for the client will be invalidated after 600 seconds regardless.

This patch applies the 600 seconds invalidation only to the displaying of the authorize form.
