### PR TITLE
added login event to firewall listener (like security.interactive_login)

### DIFF
--- a/Event/OAuthLoginEvent.php
+++ b/Event/OAuthLoginEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FOS\OAuthServerBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Class OAuthLoginEvent
+ * @author Jens Hassler <j.hassler@iwf.ch>
+ */
+class OAuthLoginEvent extends Event
+{
+    const LOGIN =  'fos_oauth_server.login';
+
+    private $authenticationToken;
+
+    /**
+     * Constructor.
+     *
+     * @param TokenInterface $authenticationToken A TokenInterface instance
+     */
+    public function __construct(TokenInterface $authenticationToken)
+    {
+        $this->authenticationToken = $authenticationToken;
+    }
+
+    /**
+     * Gets the authentication token.
+     *
+     * @return TokenInterface A TokenInterface instance
+     */
+    public function getAuthenticationToken()
+    {
+        return $this->authenticationToken;
+    }
+} 

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="security.context"/>
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="fos_oauth_server.server" />
+            <argument type="service" id="event_dispatcher" on-invalid="ignore" />
         </service>
 
         <service id="fos_oauth_server.security.entry_point" class="%fos_oauth_server.security.entry_point.class%" public="false">

--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -11,6 +11,7 @@
 
 namespace FOS\OAuthServerBundle\Security\Firewall;
 
+use FOS\OAuthServerBundle\Event\OAuthLoginEvent;
 use FOS\OAuthServerBundle\Security\Authentication\Token\OAuthToken;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
@@ -72,6 +73,11 @@ class OAuthListener implements ListenerInterface
             $returnValue = $this->authenticationManager->authenticate($token);
 
             if ($returnValue instanceof TokenInterface) {
+
+                // dispatch login event
+                $loginEvent = new OAuthLoginEvent($returnValue);
+                $event->getDispatcher()->dispatch(OAuthLoginEvent::LOGIN, $loginEvent);
+
                 return $this->securityContext->setToken($returnValue);
             }
 


### PR DESCRIPTION
I'm using the OAuthServerBundle with the Password grant to directly login users from a frontend into a backend accessible through an API. 
In the backend I normally set a lastLoginDate through the security.interactive_login event. This event is not thrown when logging in through the OAuth firewall.

I implemented a simple OAuthLogin event that is thrown when a user logs in through the OAuth firewall. The event just contains the token with the authenticated user.

Please comment if there's a better or more general way to do it. If the implementation is right, I'll also submit an appropriate test. Thanks.
