### PR TITLE
Remove reference to non-existant container service

### DIFF
--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -27,7 +27,7 @@ class FOSOAuthServerExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $processor     = new Processor();
-        $configuration = new Configuration($container->get('kernel.debug'));
+        $configuration = new Configuration();
 
         $config = $processor->processConfiguration($configuration, $configs);
 


### PR DESCRIPTION
The `Configuration` class didn't have a constructor that used this anyway.  For some reason, `hhvm` complains about it.
