### PR TITLE
Add support for extensions to prepend configuration for the db_driver option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,7 +39,6 @@ class Configuration implements ConfigurationInterface
                         ->ifNotInArray($supportedDrivers)
                         ->thenInvalid('The driver %s is not supported. Please choose one of ' . json_encode($supportedDrivers))
                     ->end()
-                    ->cannotBeOverwritten()
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()


### PR DESCRIPTION
If "cannotBeOverwritten()" is called then any extension trying to prepend the configuration can not modify the configuration value which makes the application configuration have to be more explicit. Having this support is useful when a child bundle of the FOSOAuthServerBundle might already know the DB driver that needs to be used.
