### PR TITLE
Allow custom storage service to have its own constructor signature

### DIFF
--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -44,6 +44,10 @@ class FOSOAuthServerExtension extends Extension
         $container->setAlias('fos_oauth_server.refresh_token_manager', $config['service']['refresh_token_manager']);
         $container->setAlias('fos_oauth_server.auth_code_manager', $config['service']['auth_code_manager']);
 
+        if (null !== $config['service']['user_provider']) {
+            $container->setAlias('fos_oauth_server.user_provider', new Alias($config['service']['user_provider'], false));
+        }
+
         $container->setParameter('fos_oauth_server.server.options', $config['service']['options']);
 
         $this->remapParametersNamespaces($config, $container, array(
@@ -73,11 +77,6 @@ class FOSOAuthServerExtension extends Extension
 
         if (!empty($config['authorize'])) {
             $this->loadAuthorize($config['authorize'], $container, $loader);
-        }
-
-        if (null !== $userProvider = $config['service']['user_provider']) {
-            $container->getDefinition($config['service']['storage'])
-                ->replaceArgument(4, new Reference($userProvider));
         }
     }
 

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="fos_oauth_server.access_token_manager" />
             <argument type="service" id="fos_oauth_server.refresh_token_manager" />
             <argument type="service" id="fos_oauth_server.auth_code_manager" />
-            <argument>null</argument>
+            <argument type="service" id="fos_oauth_server.user_provider" on-invalid="null" />
             <argument type="service" id="security.encoder_factory" />
         </service>
 


### PR DESCRIPTION
As @Gnucki pointed out half a year ago (FriendsOfSymfony/FOSOAuthServerBundle/pull/163): The fact that the definition of the fos_oauth_server.storage service was asked in the extension object forbade the use of a service defined in another bundle.

Also, the FOSOAuthServerExtension sets the configured userProvider as the 4th argument of the storage service. 
This doesn't make sense when using a custom storage service as it fixes the constructor signature.

This PR is a cleanup + rebase of the old PR
