### PR TITLE
Update documentation -> user provider settings

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -566,7 +566,7 @@ fos_oauth_server:
     ...
 
     service:
-        user_provider: fos_user.user_manager
+        user_provider: fos_user.user_provider.username
 ```
 
 ## Creating A Client


### PR DESCRIPTION
Current versions of FOSUserBundle warn that using UserManager as a UserProvider is deprecated and wrong!