### PR TITLE
Use common interfaces for typehinting

### DIFF
--- a/Document/AuthCodeManager.php
+++ b/Document/AuthCodeManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Document;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManager as BaseAuthCodeManager;
 
 class AuthCodeManager extends BaseAuthCodeManager
 {
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $dm;
 
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ODM\MongoDB\DocumentRepository
      */
     protected $repository;
 
@@ -32,7 +32,11 @@ class AuthCodeManager extends BaseAuthCodeManager
      */
     protected $class;
 
-    public function __construct(DocumentManager $dm, $class)
+    /**
+     * @param ObjectManager $dm
+     * @param string $class
+     */
+    public function __construct(ObjectManager $dm, $class)
     {
         $this->dm = $dm;
         $this->repository = $dm->getRepository($class);

--- a/Document/ClientManager.php
+++ b/Document/ClientManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Document;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\ClientManager as BaseClientManager;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 
 class ClientManager extends BaseClientManager
 {
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $dm;
 
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ODM\MongoDB\DocumentRepository
      */
     protected $repository;
 
@@ -32,7 +32,11 @@ class ClientManager extends BaseClientManager
      */
     protected $class;
 
-    public function __construct(DocumentManager $dm, $class)
+    /**
+     * @param ObjectManager $dm
+     * @param string $class
+     */
+    public function __construct(ObjectManager $dm, $class)
     {
         $this->dm = $dm;
         $this->repository = $dm->getRepository($class);

--- a/Document/TokenManager.php
+++ b/Document/TokenManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Document;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\TokenInterface;
 use FOS\OAuthServerBundle\Model\TokenManager as BaseTokenManager;
 
 class TokenManager extends BaseTokenManager
 {
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $dm;
 
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ODM\MongoDB\DocumentRepository
      */
     protected $repository;
 
@@ -32,7 +32,11 @@ class TokenManager extends BaseTokenManager
      */
     protected $class;
 
-    public function __construct(DocumentManager $dm, $class)
+    /**
+     * @param ObjectManager $dm
+     * @param string $class
+     */
+    public function __construct(ObjectManager $dm, $class)
     {
         $this->dm = $dm;
         $this->repository = $dm->getRepository($class);

--- a/Entity/AuthCodeManager.php
+++ b/Entity/AuthCodeManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Entity;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManager as BaseAuthCodeManager;
 
 class AuthCodeManager extends BaseAuthCodeManager
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $em;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
      */
     protected $repository;
 
@@ -33,10 +33,10 @@ class AuthCodeManager extends BaseAuthCodeManager
     protected $class;
 
     /**
-     * @param \Doctrine\ORM\EntityManager $em
+     * @param ObjectManager $em
      * @param string $class
      */
-    public function __construct(EntityManager $em, $class)
+    public function __construct(ObjectManager $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);

--- a/Entity/ClientManager.php
+++ b/Entity/ClientManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Entity;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManager as BaseClientManager;
 
 class ClientManager extends BaseClientManager
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $em;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
      */
     protected $repository;
 
@@ -32,7 +32,11 @@ class ClientManager extends BaseClientManager
      */
     protected $class;
 
-    public function __construct(EntityManager $em, $class)
+    /**
+     * @param ObjectManager $em
+     * @param string $class
+     */
+    public function __construct(ObjectManager $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);

--- a/Entity/TokenManager.php
+++ b/Entity/TokenManager.php
@@ -11,19 +11,19 @@
 
 namespace FOS\OAuthServerBundle\Entity;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\TokenInterface;
 use FOS\OAuthServerBundle\Model\TokenManager as BaseTokenManager;
 
 class TokenManager extends BaseTokenManager
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\Common\Persistence\ObjectManager
      */
     protected $em;
 
     /**
-     * @var \Doctrine\ORM\EntityRepository
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
      */
     protected $repository;
 
@@ -32,7 +32,7 @@ class TokenManager extends BaseTokenManager
      */
     protected $class;
 
-    public function __construct(EntityManager $em, $class)
+    public function __construct(ObjectManager $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);


### PR DESCRIPTION
In favor of testing and the possibility to inject custom EntityManager services, I changed the type-hinting to `Doctrine\Common\Persistence\ObjectManager` and `\Doctrine\Common\Persistence\ObjectRepository`.

Probably fixes #175 and partially #158.

This would also allow to use Neo4j as backend which I'm working on. Thoughts?
