### PR TITLE
Fix grammer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ This bundle is under the MIT license. See the complete license in the bundle:
 ## Credits
 
 - Arnaud Le Blanc, and [all contributors](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/contributors)
-- Inspirated by [BazingaOAuthBundle](https://github.com/willdurand/BazingaOAuthServerBundle) and [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle)
+- Inspired by [BazingaOAuthBundle](https://github.com/willdurand/BazingaOAuthServerBundle) and [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle)
 - Installation doc adapted from [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle) doc.


### PR DESCRIPTION
Fix a really small grammar mistake in the README. For some reason it bugged me.
