### PR TITLE
Pass the requested scope with the OAuthEvent on authorization

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -52,14 +52,14 @@ class AuthorizeController extends ContainerAware
         $form = $this->container->get('fos_oauth_server.authorize.form');
         $formHandler = $this->container->get('fos_oauth_server.authorize.form.handler');
 
+        $scope = $this->container->get('request')->get('scope', null);
+
         $event = $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            new OAuthEvent($user, $this->getClient(), false, $scope)
         );
 
         if ($event->isAuthorizedClient()) {
-            $scope = $this->container->get('request')->get('scope', null);
-
             return $this->container
                 ->get('fos_oauth_server.server')
                 ->finishClientAuthorization(true, $user, $request, $scope);
@@ -93,7 +93,7 @@ class AuthorizeController extends ContainerAware
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
+            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted(), $formHandler->getScope())
         );
 
         $formName = $this->container->get('fos_oauth_server.authorize.form')->getName();

--- a/Event/OAuthEvent.php
+++ b/Event/OAuthEvent.php
@@ -37,13 +37,19 @@ class OAuthEvent extends Event
     private $isAuthorizedClient;
 
     /**
+     * @var string|null
+     */
+    private $scope;
+
+    /**
      * @param UserInterface $user
      */
-    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false)
+    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false, $scope = null)
     {
         $this->user = $user;
         $this->client = $client;
         $this->isAuthorizedClient = $isAuthorizedClient;
+        $this->scope = $scope;
     }
 
     /**
@@ -76,5 +82,13 @@ class OAuthEvent extends Event
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getScope()
+    {
+        return $this->scope;
     }
 }


### PR DESCRIPTION
Pass along the scope that is requested in the authorization process, so listeners to the pre/post authorization events can use it.

Fixes #182
