### PR TITLE
Fix deprecated factory definition

### DIFF
--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="fos_oauth_server.authorize.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="fos_oauth_server.authorize.form" class="Symfony\Component\Form\Form">
             <argument>%fos_oauth_server.authorize.form.name%</argument>
             <argument>%fos_oauth_server.authorize.form.type%</argument>
             <argument>null</argument>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -25,7 +25,7 @@
             <argument>%fos_oauth_server.model.auth_code.class%</argument>
         </service>
 
-        <service id="fos_oauth_server.entity_manager" factory-service="doctrine" factory-method="getManager" class="Doctrine\ORM\EntityManager" public="false">
+        <service id="fos_oauth_server.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
             <argument>%fos_oauth_server.model_manager_name%</argument>
         </service>
     </services>


### PR DESCRIPTION
This PR replace `factory-service` and `factory-method` attributes by `factory` section, according to Symfony deprecate rules.

Had to do this on the extension class instead of xml config to keep Symfony 2.3+ BC.

Regards.