### PR TITLE
Travis improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,42 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
+  - nightly
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.5.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.6.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2.6"
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+    - env: SYMFONY_VERSION=2.7.*@dev
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2.6"
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 before_script:
   - echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
-  - composer install --dev --prefer-dist --no-interaction
+  - composer selfupdate
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 phpunit: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "symfony/class-loader": "~2.1",
         "symfony/yaml": "~2.1",
-        "willdurand/propel-typehintable-behavior": "1.0.*",
+        "willdurand/propel-typehintable-behavior": "~1.0,>1.0.4",
         "doctrine/mongodb-odm": "1.0.*@dev",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/orm": ">=2.2,<2.5-dev"


### PR DESCRIPTION
This PR is a Travis improvement suggestion.

With this new config, we have:

 * Tests from php 5.3 to 5.6
 * Tests form SF 2.3 to 2.6 and 2.7/2.8/3.0 allowed failure (in order to prevent deprecated issues)
 * Cache system to make tests quicker

Don't hesitate to tell me your thinking about this suggestion! :+1: 

Thanks