### PR TITLE
Fix deprecated forms setDefaultOptions method

### DIFF
--- a/Form/Type/AuthorizeFormType.php
+++ b/Form/Type/AuthorizeFormType.php
@@ -13,6 +13,7 @@ namespace FOS\OAuthServerBundle\Form\Type;
 
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -31,8 +32,18 @@ class AuthorizeFormType extends AbstractType
 
     /**
      * {@inheritdoc}
+     *
+     * @todo Remove it when bumping requirements to SF 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'FOS\OAuthServerBundle\Form\Model\Authorize'


### PR DESCRIPTION
This PR fixes deprecated notices since SF 2.7.

Symfony 2.3+ BC kept.