### PR TITLE
Fix deprecated SecurityContextInterface usage

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -36,7 +36,13 @@ class OAuthFactory implements SecurityFactoryInterface
             ;
 
         $listenerId = 'security.authentication.listener.fos_oauth_server.'.$id;
-        $container->setDefinition($listenerId, new DefinitionDecorator('fos_oauth_server.security.authentication.listener'));
+        // Set the SecurityContext for Symfony <2.6
+        $tokenStorageReference = interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ? new Reference('security.token_storage') : new Reference('security.context');
+        $container
+            ->setDefinition($listenerId, new DefinitionDecorator('fos_oauth_server.security.authentication.listener'))
+            ->replaceArgument(0, $tokenStorageReference)
+        ;
 
         return array($providerId, $listenerId, 'fos_oauth_server.security.entry_point');
     }

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -18,7 +18,7 @@
         </service>
 
         <service id="fos_oauth_server.security.authentication.listener" class="%fos_oauth_server.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="fos_oauth_server.server" />
         </service>

--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -16,6 +16,7 @@ use OAuth2\OAuth2;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -29,34 +30,47 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 class OAuthListener implements ListenerInterface
 {
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var SecurityContextInterface
+     *
+     * @deprecated since 1.4.3, to be removed in 2.0
      */
     protected $securityContext;
 
     /**
-     * @var \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface
+     * @var AuthenticationManagerInterface
      */
     protected $authenticationManager;
 
     /**
-     * @var \OAuth2\OAuth2
+     * @var OAuth2
      */
     protected $serverService;
 
     /**
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface                      $securityContext       The security context.
-     * @param \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface $authenticationManager The authentication manager.
-     * @param \OAuth2\OAuth2                                                                 $serverService
+     * @var TokenStorageInterface|SecurityContextInterface
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
+    private $tokenStorage;
+
+    /**
+     * @param TokenStorageInterface|SecurityContextInterface    $tokenStorage
+     * @param AuthenticationManagerInterface                    $authenticationManager The authentication manager.
+     * @param OAuth2                                            $serverService
+     */
+    public function __construct($tokenStorage, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
     {
-        $this->securityContext = $securityContext;
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException(sprintf('Argument 1 of %s should be an instance of TokenStorageInterface or SecurityContextInterface', __CLASS__));
+        }
+
+        $this->tokenStorage = $tokenStorage;
+        // Property name BC
+        $this->securityContext = $this->tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->serverService = $serverService;
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event The event.
+     * @param GetResponseEvent $event The event.
      */
     public function handle(GetResponseEvent $event)
     {
@@ -71,7 +85,7 @@ class OAuthListener implements ListenerInterface
             $returnValue = $this->authenticationManager->authenticate($token);
 
             if ($returnValue instanceof TokenInterface) {
-                return $this->securityContext->setToken($returnValue);
+                return $this->tokenStorage->setToken($returnValue);
             }
 
             if ($returnValue instanceof Response) {
@@ -83,4 +97,5 @@ class OAuthListener implements ListenerInterface
             }
         }
     }
+
 }

--- a/Tests/DependencyInjection/Security/Factory/OAuthFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/OAuthFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FOS\OAuthServerBundle\Tests\DependencyInjection\Security\Factory;
+
+use FOS\OAuthServerBundle\DependencyInjection\Security\Factory\OAuthFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OAuthFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('auth_provider');
+
+        $factory = new OAuthFactory();
+
+        list($authProviderId,
+            $listenerId,
+            $entryPointId
+            ) = $factory->create($container, 'default', array(), 'user_provider', 'entry_point');
+
+        $this->assertEquals('security.authentication.provider.fos_oauth_server.default', $authProviderId);
+        $this->assertEquals('security.authentication.listener.fos_oauth_server.default', $listenerId);
+        $this->assertEquals('fos_oauth_server.security.entry_point', $entryPointId);
+
+        $expectedTokenStorageService = interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ? 'security.token_storage' : 'security.context'
+        ;
+        $this->assertEquals($expectedTokenStorageService, (string) $container->getDefinition($listenerId)->getArgument(0));
+
+        $this->assertEquals('pre_auth', $factory->getPosition());
+        $this->assertEquals('fos_oauth', $factory->getKey());
+    }
+}

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -20,7 +20,7 @@ class OAuthListenerTest extends TestCase
 
     protected $authManager;
 
-    protected $securityContext;
+    protected $tokenStorage;
 
     protected $event;
 
@@ -34,8 +34,13 @@ class OAuthListenerTest extends TestCase
         $this->authManager = $this
             ->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $this->securityContext = $this
-            ->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $this->tokenStorage = $this
+                ->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        } else {
+            $this->tokenStorage = $this
+                ->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        }
 
         $this->event = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
@@ -45,7 +50,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandle()
     {
-        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())
@@ -57,7 +62,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnArgument(0));
 
-        $this->securityContext
+        $this->tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->will($this->returnArgument(0));
@@ -70,7 +75,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandleResponse()
     {
-        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())
@@ -84,7 +89,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnValue($response));
 
-        $this->securityContext
+        $this->tokenStorage
             ->expects($this->never())
             ->method('setToken');
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.3",
         "friendsofsymfony/oauth2-php": "~1.1.0",
         "symfony/framework-bundle": "~2.2",
+        "symfony/dependency-injection": "~2.1",
         "symfony/security-bundle": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR fix deprecated SecurityContextInterface usage, introduce since Symfony 2.6.

Symfony 2.3+ BC kept.

@willdurand @stof Have you any suggestion of how handle it easily? Thanks.