### PR TITLE
Fix deprecated routing configuration

### DIFF
--- a/Resources/config/routing/authorize.xml
+++ b/Resources/config/routing/authorize.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_oauth_server_authorize" pattern="/oauth/v2/auth">
+    <route id="fos_oauth_server_authorize" path="/oauth/v2/auth" methods="GET POST">
         <default key="_controller">FOSOAuthServerBundle:Authorize:authorize</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/token.xml
+++ b/Resources/config/routing/token.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_oauth_server_token" pattern="/oauth/v2/token">
+    <route id="fos_oauth_server_token" path="/oauth/v2/token" methods="GET POST">
         <default key="_controller">fos_oauth_server.controller.token:tokenAction</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
+++ b/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
+
+class FOSOAuthServerExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoadAuthorizeRouting()
+    {
+        $locator = new FileLocator();
+        $loader = new XmlFileLoader($locator);
+
+        $collection = $loader->load(__DIR__.'/../../Resources/config/routing/authorize.xml');
+        $authorizeRoute = $collection->get('fos_oauth_server_authorize');
+        $this->assertEquals('/oauth/v2/auth', $authorizeRoute->getPath());
+        $this->assertEquals(array('GET', 'POST'), $authorizeRoute->getMethods());
+    }
+
+    public function testLoadTokenRouting()
+    {
+        $locator = new FileLocator();
+        $loader = new XmlFileLoader($locator);
+
+        $collection = $loader->load(__DIR__.'/../../Resources/config/routing/token.xml');
+        $tokenRoute = $collection->get('fos_oauth_server_token');
+        $this->assertEquals('/oauth/v2/token', $tokenRoute->getPath());
+        $this->assertEquals(array('GET', 'POST'), $tokenRoute->getMethods());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "friendsofsymfony/oauth2-php": "~1.1.0",
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "~2.2",
         "symfony/security-bundle": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "pattern" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.

> The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.

We have to bump `symfony/framework-bundle` to `~2.2` version. Not a big deal because 2.1 is not maintained anymore.

The added tests reveal the errors by loading routing configuration files.