### PR TITLE
Do not depend on deprecated 'request' service, removed in symfony 3.0

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -54,11 +54,11 @@ class AuthorizeController extends ContainerAware
 
         $event = $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            new OAuthEvent($user, $this->getClient($request))
         );
 
         if ($event->isAuthorizedClient()) {
-            $scope = $this->container->get('request')->get('scope', null);
+            $scope = $request->get('scope', null);
 
             return $this->container
                 ->get('fos_oauth_server.server')
@@ -73,7 +73,7 @@ class AuthorizeController extends ContainerAware
             'FOSOAuthServerBundle:Authorize:authorize.html.' . $this->container->getParameter('fos_oauth_server.template.engine'),
             array(
                 'form'      => $form->createView(),
-                'client'    => $this->getClient(),
+                'client'    => $this->getClient($request),
             )
         );
     }
@@ -93,7 +93,7 @@ class AuthorizeController extends ContainerAware
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
+            new OAuthEvent($user, $this->getClient($request), $formHandler->isAccepted())
         );
 
         $formName = $this->container->get('fos_oauth_server.authorize.form')->getName();
@@ -124,12 +124,12 @@ class AuthorizeController extends ContainerAware
     /**
      * @return ClientInterface
      */
-    protected function getClient()
+    protected function getClient(Request $request)
     {
         if (null === $this->client) {
-            if (null === $clientId = $this->container->get('request')->get('client_id')) {
+            if (null === $clientId = $request->get('client_id')) {
                 $form = $this->container->get('fos_oauth_server.authorize.form');
-                $clientId = $this->container->get('request')
+                $clientId = $request
                     ->get(sprintf('%s[client_id]', $form->getName()), null, true);
             }
 

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -65,7 +65,7 @@ class AuthorizeController extends ContainerAware
                 ->finishClientAuthorization(true, $user, $request, $scope);
         }
 
-        if (true === $formHandler->process()) {
+        if (true === $formHandler->process($request)) {
             return $this->processSuccess($user, $formHandler, $request);
         }
 

--- a/Form/Handler/AuthorizeFormHandler.php
+++ b/Form/Handler/AuthorizeFormHandler.php
@@ -20,13 +20,11 @@ use FOS\OAuthServerBundle\Form\Model\Authorize;
  */
 class AuthorizeFormHandler
 {
-    protected $request;
     protected $form;
 
-    public function __construct(FormInterface $form, Request $request)
+    public function __construct(FormInterface $form)
     {
         $this->form = $form;
-        $this->request = $request;
     }
 
     public function isAccepted()
@@ -39,15 +37,15 @@ class AuthorizeFormHandler
         return !$this->form->getData()->accepted;
     }
 
-    public function process()
+    public function process(Request $request)
     {
         $this->form->setData(new Authorize(
-            $this->request->request->has('accepted'),
-            $this->request->query->all()
+            $request->request->has('accepted'),
+            $request->query->all()
         ));
 
-        if ('POST' === $this->request->getMethod()) {
-            $this->form->bind($this->request);
+        if ('POST' === $request->getMethod()) {
+            $this->form->bind($request);
             if ($this->form->isValid()) {
                 $this->onSuccess();
 

--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -18,9 +18,8 @@
             <tag name="form.type" alias="fos_oauth_server_authorize" />
         </service>
 
-        <service id="fos_oauth_server.authorize.form.handler.default" class="FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler" scope="request">
+        <service id="fos_oauth_server.authorize.form.handler.default" class="FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler">
             <argument type="service" id="fos_oauth_server.authorize.form" />
-            <argument type="service" id="request" />
         </service>
     </services>
 


### PR DESCRIPTION
The 'request' service is deprecated in symfony 2.4, and removed in symfony 3.0.
The alternative is to let the request be injected in the controller, and pass it as a parameter to the methods that require a request.
Another possibility is injecting the 'request_stack' service, but this would not be compatible with symfony < 2.4