### PR TITLE
Pass OAuth scopes to the OAuthEvent

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -52,14 +52,14 @@ class AuthorizeController extends ContainerAware
         $form = $this->container->get('fos_oauth_server.authorize.form');
         $formHandler = $this->container->get('fos_oauth_server.authorize.form.handler');
 
+        $scope = $request->query->get('scope', $request->request->get($form->getName().'[scope]', null, true));
+
         $event = $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            new OAuthEvent($user, $this->getClient(), false, $scope)
         );
 
         if ($event->isAuthorizedClient()) {
-            $scope = $this->container->get('request')->get('scope', null);
-
             return $this->container
                 ->get('fos_oauth_server.server')
                 ->finishClientAuthorization(true, $user, $request, $scope);
@@ -93,7 +93,7 @@ class AuthorizeController extends ContainerAware
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
+            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted(), $formHandler->getScope())
         );
 
         $formName = $this->container->get('fos_oauth_server.authorize.form')->getName();

--- a/Event/OAuthEvent.php
+++ b/Event/OAuthEvent.php
@@ -37,14 +37,14 @@ class OAuthEvent extends Event
     private $isAuthorizedClient;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $scopes;
 
     /**
      * @param UserInterface $user
      */
-    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false, $scopes = '')
+    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false, $scopes = null)
     {
         $this->user = $user;
         $this->client = $client;
@@ -85,7 +85,7 @@ class OAuthEvent extends Event
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getScopes()
     {

--- a/Event/OAuthEvent.php
+++ b/Event/OAuthEvent.php
@@ -37,13 +37,19 @@ class OAuthEvent extends Event
     private $isAuthorizedClient;
 
     /**
+     * @var string
+     */
+    private $scopes;
+
+    /**
      * @param UserInterface $user
      */
-    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false)
+    public function __construct(UserInterface $user, ClientInterface $client, $isAuthorizedClient = false, $scopes = '')
     {
         $this->user = $user;
         $this->client = $client;
         $this->isAuthorizedClient = $isAuthorizedClient;
+        $this->scopes = $scopes;
     }
 
     /**
@@ -76,5 +82,13 @@ class OAuthEvent extends Event
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
     }
 }


### PR DESCRIPTION
An eventlistener on `pre/post_authorization_process` may be interested in the scopes the OAuth client requested. (For example to show the authorization page again when the scopes the app requests have changed since the last authorization)

This PR adds one extra optional parameter to `OAuthEvent`, and thus is fully backwards compatible with previous versions.
