### PR TITLE
Change Symfony versions tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.6.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*@dev
+      env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*@dev
     - php: 5.6
@@ -28,7 +24,6 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
-    - env: SYMFONY_VERSION=2.7.*@dev
     - env: SYMFONY_VERSION=2.8.*@dev
     - env: SYMFONY_VERSION="3.0.x-dev as 2.6"
 


### PR DESCRIPTION
* Removed 2.5 as deprecated version
* Added 2.7 on required tests as stable version is now available