### PR TITLE
Use parameters to define class for service

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="fos_oauth_server.server.class">OAuth2\OAuth2</parameter>
+        <parameter key="fos_oauth_server.controller.token.class">FOS\OAuthServerBundle\Controller\TokenController1</parameter>
     </parameters>
 
     <services>
@@ -23,7 +24,7 @@
             <argument>%fos_oauth_server.server.options%</argument>
         </service>
 
-        <service id="fos_oauth_server.controller.token" class="FOS\OAuthServerBundle\Controller\TokenController">
+        <service id="fos_oauth_server.controller.token" class="%fos_oauth_server.controller.token.class%">
             <argument type="service" id="fos_oauth_server.server" />
         </service>
     </services>


### PR DESCRIPTION
It will allow to override class that should be used for this service and will allow to extend functionality without creating CompilerPass.