### PR TITLE
Added config to client to make possible to skip authorize step

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -57,7 +57,7 @@ class AuthorizeController extends ContainerAware
             new OAuthEvent($user, $this->getClient())
         );
 
-        if ($event->isAuthorizedClient()) {
+        if ($this->getClient()->getAuthorizeAutomatically() || $event->isAuthorizedClient()) {
             $scope = $this->container->get('request')->get('scope', null);
 
             return $this->container

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -41,6 +41,11 @@ class Client implements ClientInterface
      */
     protected $allowedGrantTypes;
 
+    /**
+     * @var boolean
+     */
+    protected $authorizeAutomatically = false;
+
     public function __construct()
     {
         $this->allowedGrantTypes = array(
@@ -134,5 +139,21 @@ class Client implements ClientInterface
     public function getAllowedGrantTypes()
     {
         return $this->allowedGrantTypes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthorizeAutomatically($value)
+    {
+        $this->authorizeAutomatically = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizeAutomatically()
+    {
+        return $this->authorizeAutomatically;
     }
 }

--- a/Model/ClientInterface.php
+++ b/Model/ClientInterface.php
@@ -55,4 +55,14 @@ interface ClientInterface extends IOAuth2Client
      * @return array
      */
     public function getAllowedGrantTypes();
+
+    /**
+     * @param $value
+     */
+    public function setAuthorizeAutomatically($value);
+
+    /**
+     * @return boolean
+     */
+    public function getAuthorizeAutomatically();
 }

--- a/Resources/config/doctrine/Client.orm.xml
+++ b/Resources/config/doctrine/Client.orm.xml
@@ -9,5 +9,6 @@
         <field name="redirectUris" column="redirect_uris" type="array" />
         <field name="secret" column="secret" type="string" />
         <field name="allowedGrantTypes" column="allowed_grant_types" type="array" />
+        <field name="authorizeAutomatically" column="authorize_automatically" type="boolean" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -6,6 +6,7 @@
         <column name="redirect_uris" type="array" required="true" />
         <column name="secret" type="varchar" required="true" />
         <column name="allowed_grant_types" type="array" required="true" />
+        <column name="authorize_automatically" type="boolean" required="true" />
 
         <behavior name="typehintable">
             <parameter name="redirect_uris" value="array" />


### PR DESCRIPTION
I needed this option to make process faster and automated. 
Now, when creating new client just set value:
```php
$client->setAuthorizeAutomatically(TRUE);
```
and you won't see form on oauth/v2/auth site