### PR TITLE
Remove deprecated code and add new implementation for Symfony 3.0

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -54,18 +54,18 @@ class AuthorizeController extends ContainerAware
 
         $event = $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            new OAuthEvent($user, $this->getClient($request))
         );
 
         if ($event->isAuthorizedClient()) {
-            $scope = $this->container->get('request')->get('scope', null);
+            $scope = $request->get('scope', null);
 
             return $this->container
                 ->get('fos_oauth_server.server')
                 ->finishClientAuthorization(true, $user, $request, $scope);
         }
 
-        if (true === $formHandler->process()) {
+        if (true === $formHandler->process($request)) {
             return $this->processSuccess($user, $formHandler, $request);
         }
 
@@ -73,14 +73,15 @@ class AuthorizeController extends ContainerAware
             'FOSOAuthServerBundle:Authorize:authorize.html.' . $this->container->getParameter('fos_oauth_server.template.engine'),
             array(
                 'form'      => $form->createView(),
-                'client'    => $this->getClient(),
+                'client'    => $this->getClient($request),
             )
         );
     }
 
     /**
-     * @param UserInterface        $user
+     * @param UserInterface $user
      * @param AuthorizeFormHandler $formHandler
+     * @param Request $request
      *
      * @return Response
      */
@@ -93,7 +94,7 @@ class AuthorizeController extends ContainerAware
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
+            new OAuthEvent($user, $this->getClient($request), $formHandler->isAccepted())
         );
 
         $formName = $this->container->get('fos_oauth_server.authorize.form')->getName();
@@ -124,13 +125,12 @@ class AuthorizeController extends ContainerAware
     /**
      * @return ClientInterface
      */
-    protected function getClient()
+    protected function getClient(Request $request)
     {
         if (null === $this->client) {
-            if (null === $clientId = $this->container->get('request')->get('client_id')) {
+            if (null === $clientId = $request->get('client_id')) {
                 $form = $this->container->get('fos_oauth_server.authorize.form');
-                $clientId = $this->container->get('request')
-                    ->get(sprintf('%s[client_id]', $form->getName()), null, true);
+                $clientId = $request->get(sprintf('%s[client_id]', $form->getName()), null, true);
             }
 
             $client = $this->container

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -54,7 +54,7 @@ class AuthorizeController extends ContainerAware
 
         $event = $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient($request))
+            new OAuthEvent($user, $this->getClient())
         );
 
         if ($event->isAuthorizedClient()) {
@@ -73,7 +73,7 @@ class AuthorizeController extends ContainerAware
             'FOSOAuthServerBundle:Authorize:authorize.html.' . $this->container->getParameter('fos_oauth_server.template.engine'),
             array(
                 'form'      => $form->createView(),
-                'client'    => $this->getClient($request),
+                'client'    => $this->getClient(),
             )
         );
     }
@@ -94,7 +94,7 @@ class AuthorizeController extends ContainerAware
 
         $this->container->get('event_dispatcher')->dispatch(
             OAuthEvent::POST_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient($request), $formHandler->isAccepted())
+            new OAuthEvent($user, $this->getClient(), $formHandler->isAccepted())
         );
 
         $formName = $this->container->get('fos_oauth_server.authorize.form')->getName();
@@ -125,8 +125,9 @@ class AuthorizeController extends ContainerAware
     /**
      * @return ClientInterface
      */
-    protected function getClient(Request $request)
+    protected function getClient()
     {
+        $request = $this->container->get('request_stack')->getMasterRequest();
         if (null === $this->client) {
             if (null === $clientId = $request->get('client_id')) {
                 $form = $this->container->get('fos_oauth_server.authorize.form');

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -65,7 +65,7 @@ class AuthorizeController extends ContainerAware
                 ->finishClientAuthorization(true, $user, $request, $scope);
         }
 
-        if (true === $formHandler->process($request)) {
+        if (true === $formHandler->process()) {
             return $this->processSuccess($user, $formHandler, $request);
         }
 

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -79,7 +79,7 @@ class AuthorizeController extends ContainerAware
     }
 
     /**
-     * @param UserInterface $user
+     * @param UserInterface        $user
      * @param AuthorizeFormHandler $formHandler
      * @param Request $request
      *
@@ -127,7 +127,7 @@ class AuthorizeController extends ContainerAware
      */
     protected function getClient()
     {
-        $request = $this->container->get('request_stack')->getMasterRequest();
+        $request = $this->container->get('request_stack')->getCurrentRequest();
         if (null === $this->client) {
             if (null === $clientId = $request->get('client_id')) {
                 $form = $this->container->get('fos_oauth_server.authorize.form');

--- a/DependencyInjection/Compiler/TokenStorageCompilerPass.php
+++ b/DependencyInjection/Compiler/TokenStorageCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\OAuthServerBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -18,7 +27,7 @@ class TokenStorageCompilerPass implements CompilerPassInterface
     {
         $definition = $container->getDefinition('fos_oauth_server.security.authentication.listener');
 
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+        if ($container->hasDefinition('security.token_storage')) {
             $tokenStorageReference = new Reference('security.token_storage');
         } else {
             $tokenStorageReference = new Reference('security.context');

--- a/DependencyInjection/Compiler/TokenStorageCompilerPass.php
+++ b/DependencyInjection/Compiler/TokenStorageCompilerPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FOS\OAuthServerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Andras Ratz <ratz.andras86@gmail.com>
+ */
+class TokenStorageCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('fos_oauth_server.security.authentication.listener');
+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+        $definition->replaceArgument(0, $tokenStorageReference);
+    }
+
+}

--- a/FOSOAuthServerBundle.php
+++ b/FOSOAuthServerBundle.php
@@ -11,6 +11,7 @@
 
 namespace FOS\OAuthServerBundle;
 
+use FOS\OAuthServerBundle\DependencyInjection\Compiler\TokenStorageCompilerPass;
 use FOS\OAuthServerBundle\DependencyInjection\FOSOAuthServerExtension;
 use FOS\OAuthServerBundle\DependencyInjection\Security\Factory\OAuthFactory;
 use FOS\OAuthServerBundle\DependencyInjection\Compiler\GrantExtensionsCompilerPass;
@@ -35,5 +36,6 @@ class FOSOAuthServerBundle extends Bundle
         }
 
         $container->addCompilerPass(new GrantExtensionsCompilerPass());
+        $container->addCompilerPass(new TokenStorageCompilerPass());
     }
 }

--- a/Form/Handler/AuthorizeFormHandler.php
+++ b/Form/Handler/AuthorizeFormHandler.php
@@ -24,10 +24,15 @@ class AuthorizeFormHandler
     protected $request;
     protected $form;
 
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
     public function __construct(FormInterface $form, RequestStack $requestStack)
     {
         $this->form = $form;
-        $this->request = $requestStack->getMasterRequest();
+        $this->requestStack = $requestStack;
     }
 
     public function isAccepted()
@@ -42,6 +47,8 @@ class AuthorizeFormHandler
 
     public function process()
     {
+        $this->request = $this->requestStack->getCurrentRequest();
+
         $this->form->setData(new Authorize(
             $this->request->request->has('accepted'),
             $this->request->query->all()

--- a/Form/Handler/AuthorizeFormHandler.php
+++ b/Form/Handler/AuthorizeFormHandler.php
@@ -14,6 +14,7 @@ namespace FOS\OAuthServerBundle\Form\Handler;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use FOS\OAuthServerBundle\Form\Model\Authorize;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @author Chris Jones <leeked@gmail.com>
@@ -23,9 +24,10 @@ class AuthorizeFormHandler
     protected $request;
     protected $form;
 
-    public function __construct(FormInterface $form)
+    public function __construct(FormInterface $form, RequestStack $requestStack)
     {
         $this->form = $form;
+        $this->request = $requestStack->getMasterRequest();
     }
 
     public function isAccepted()
@@ -38,15 +40,15 @@ class AuthorizeFormHandler
         return !$this->form->getData()->accepted;
     }
 
-    public function process(Request $request)
+    public function process()
     {
         $this->form->setData(new Authorize(
-            $request->request->has('accepted'),
-            $request->query->all()
+            $this->request->request->has('accepted'),
+            $this->request->query->all()
         ));
 
-        if ('POST' === $request->getMethod()) {
-            $this->form->submit($request);
+        if ('POST' === $this->request->getMethod()) {
+            $this->form->submit($this->request);
             if ($this->form->isValid()) {
                 $this->onSuccess();
 

--- a/Form/Handler/AuthorizeFormHandler.php
+++ b/Form/Handler/AuthorizeFormHandler.php
@@ -23,10 +23,9 @@ class AuthorizeFormHandler
     protected $request;
     protected $form;
 
-    public function __construct(FormInterface $form, Request $request)
+    public function __construct(FormInterface $form)
     {
         $this->form = $form;
-        $this->request = $request;
     }
 
     public function isAccepted()
@@ -39,15 +38,15 @@ class AuthorizeFormHandler
         return !$this->form->getData()->accepted;
     }
 
-    public function process()
+    public function process(Request $request)
     {
         $this->form->setData(new Authorize(
-            $this->request->request->has('accepted'),
-            $this->request->query->all()
+            $request->request->has('accepted'),
+            $request->query->all()
         ));
 
-        if ('POST' === $this->request->getMethod()) {
-            $this->form->bind($this->request);
+        if ('POST' === $request->getMethod()) {
+            $this->form->submit($request);
             if ($this->form->isValid()) {
                 $this->onSuccess();
 

--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -18,9 +18,8 @@
             <tag name="form.type" alias="fos_oauth_server_authorize" />
         </service>
 
-        <service id="fos_oauth_server.authorize.form.handler.default" class="FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler" scope="request">
+        <service id="fos_oauth_server.authorize.form.handler.default" class="FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler">
             <argument type="service" id="fos_oauth_server.authorize.form" />
-            <argument type="service" id="request" />
         </service>
     </services>
 

--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -20,6 +20,7 @@
 
         <service id="fos_oauth_server.authorize.form.handler.default" class="FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler">
             <argument type="service" id="fos_oauth_server.authorize.form" />
+            <argument type="service" id="request_stack" />
         </service>
     </services>
 

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -18,7 +18,7 @@
         </service>
 
         <service id="fos_oauth_server.security.authentication.listener" class="%fos_oauth_server.security.authentication.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument /> <!-- security.token_storage or security.context for Symfony < 2.6 -->
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="fos_oauth_server.server" />
         </service>

--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -17,8 +17,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
@@ -29,9 +29,9 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 class OAuthListener implements ListenerInterface
 {
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface
@@ -44,13 +44,13 @@ class OAuthListener implements ListenerInterface
     protected $serverService;
 
     /**
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface                      $securityContext       The security context.
-     * @param \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface $authenticationManager The authentication manager.
-     * @param \OAuth2\OAuth2                                                                 $serverService
+     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface   $tokenStorage          The token storage.
+     * @param \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface        $authenticationManager The authentication manager.
+     * @param \OAuth2\OAuth2                                                                        $serverService
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->serverService = $serverService;
     }
@@ -71,7 +71,7 @@ class OAuthListener implements ListenerInterface
             $returnValue = $this->authenticationManager->authenticate($token);
 
             if ($returnValue instanceof TokenInterface) {
-                return $this->securityContext->setToken($returnValue);
+                return $this->tokenStorage->setToken($returnValue);
             }
 
             if ($returnValue instanceof Response) {

--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -51,6 +51,9 @@ class OAuthListener implements ListenerInterface
      */
     public function __construct($securityContext, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
     {
+        if (!$securityContext instanceof  TokenStorageInterface && !$securityContext instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Wrong type for OAuthListener, it has to implement TokenStorageInterface or SecurityContextInterface');
+        }
         $this->securityContext = $securityContext;
         $this->authenticationManager = $authenticationManager;
         $this->serverService = $serverService;

--- a/Security/Firewall/OAuthListener.php
+++ b/Security/Firewall/OAuthListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
@@ -29,9 +30,9 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 class OAuthListener implements ListenerInterface
 {
     /**
-     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|\Symfony\Component\Security\Core\SecurityContextInterface
      */
-    protected $tokenStorage;
+    protected $securityContext;
 
     /**
      * @var \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface
@@ -44,13 +45,13 @@ class OAuthListener implements ListenerInterface
     protected $serverService;
 
     /**
-     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface   $tokenStorage          The token storage.
+     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|\Symfony\Component\Security\Core\SecurityContextInterface   $tokenStorage          The token storage.
      * @param \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface        $authenticationManager The authentication manager.
      * @param \OAuth2\OAuth2                                                                        $serverService
      */
-    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
+    public function __construct($securityContext, AuthenticationManagerInterface $authenticationManager, OAuth2 $serverService)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->securityContext = $securityContext;
         $this->authenticationManager = $authenticationManager;
         $this->serverService = $serverService;
     }
@@ -71,7 +72,7 @@ class OAuthListener implements ListenerInterface
             $returnValue = $this->authenticationManager->authenticate($token);
 
             if ($returnValue instanceof TokenInterface) {
-                return $this->tokenStorage->setToken($returnValue);
+                return $this->securityContext->setToken($returnValue);
             }
 
             if ($returnValue instanceof Response) {

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -89,7 +89,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnValue($response));
 
-        $this->tokenStorage
+        $this->securityContext
             ->expects($this->never())
             ->method('setToken');
 

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -34,8 +34,13 @@ class OAuthListenerTest extends TestCase
         $this->authManager = $this
             ->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $this->tokenStorage = $this
-            ->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $this->tokenStorage = $this
+                ->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        } else {
+            $this->tokenStorage = $this
+                ->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        }
 
         $this->event = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -103,4 +103,10 @@ class OAuthListenerTest extends TestCase
         $this->assertEquals($response, $ret);
     }
 
+    public function testWrongTypeForOAuthListener()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $listener = new OAuthListener($this->event, $this->authManager, $this->serverService);
+    }
+
 }

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -20,7 +20,7 @@ class OAuthListenerTest extends TestCase
 
     protected $authManager;
 
-    protected $tokenStorage;
+    protected $securityContext;
 
     protected $event;
 
@@ -35,10 +35,10 @@ class OAuthListenerTest extends TestCase
             ->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $this->tokenStorage = $this
+            $this->securityContext = $this
                 ->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         } else {
-            $this->tokenStorage = $this
+            $this->securityContext = $this
                 ->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
@@ -50,7 +50,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandle()
     {
-        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())
@@ -62,7 +62,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnArgument(0));
 
-        $this->tokenStorage
+        $this->securityContext
             ->expects($this->once())
             ->method('setToken')
             ->will($this->returnArgument(0));
@@ -75,7 +75,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandleResponse()
     {
-        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -20,7 +20,7 @@ class OAuthListenerTest extends TestCase
 
     protected $authManager;
 
-    protected $securityContext;
+    protected $tokenStorage;
 
     protected $event;
 
@@ -34,8 +34,8 @@ class OAuthListenerTest extends TestCase
         $this->authManager = $this
             ->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
 
-        $this->securityContext = $this
-            ->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $this->tokenStorage = $this
+            ->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
 
         $this->event = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
@@ -45,7 +45,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandle()
     {
-        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())
@@ -57,7 +57,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnArgument(0));
 
-        $this->securityContext
+        $this->tokenStorage
             ->expects($this->once())
             ->method('setToken')
             ->will($this->returnArgument(0));
@@ -70,7 +70,7 @@ class OAuthListenerTest extends TestCase
 
     public function testHandleResponse()
     {
-        $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
+        $listener = new OAuthListener($this->tokenStorage, $this->authManager, $this->serverService);
 
         $this->serverService
             ->expects($this->once())
@@ -84,7 +84,7 @@ class OAuthListenerTest extends TestCase
             ->method('authenticate')
             ->will($this->returnValue($response));
 
-        $this->securityContext
+        $this->tokenStorage
             ->expects($this->never())
             ->method('setToken');
 


### PR DESCRIPTION
As Symfony 3.0 will be released in a month, this bundle should be updated so it can be used with the newer version.
- `SecurityContext` removed and added `TokenStorage` for `OAuthListener`
- Test is fixed for `OAuthListener`
- In FormHandler the `bind` method was removed and `submit` was added
- The `request` service is removed, the `request` is passed in as a function argument 