### PR TITLE
Add create client command

### DIFF
--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace FOS\OAuthServerBundle\Command;
+
+use FOS\OAuthServerBundle\Model\ClientManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateClientCommand extends Command
+{
+    const OPTION_REDIRECT_URI = 'redirect-uri';
+    const OPTION_GRANT_TYPE = 'grant-type';
+
+    /**
+     * @var ClientManager
+     */
+    private $clientManager;
+
+    public function __construct(ClientManager $clientManager)
+    {
+        parent::__construct();
+
+        $this->clientManager = $clientManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:oauth-server:create-client')
+            ->setDescription('Create a new OAuth client')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command will create a new OAuth2 client.
+
+  <info>php %command.full_name%</info>
+EOT
+            )
+            ->addOption(
+                self::OPTION_REDIRECT_URI,
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'If set add a redirect uri'
+            )
+            ->addOption(
+                self::OPTION_GRANT_TYPE,
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'If set add a grant type'
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $client = $this->clientManager->createClient();
+        $client->setRedirectUris($input->getOption(self::OPTION_REDIRECT_URI));
+        $client->setAllowedGrantTypes($input->getOption(self::OPTION_GRANT_TYPE));
+        $this->clientManager->updateClient($client);
+
+        $output->writeln('Client created');
+        $output->writeln('client_id='.$client->getId().'_'.$client->getRandomId());
+        $output->writeln('client_secret='.$client->getSecret());
+    }
+}

--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -34,7 +34,7 @@ class FOSOAuthServerExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load(sprintf('%s.xml', $config['db_driver']));
 
-        foreach (array('oauth', 'security') as $basename) {
+        foreach (array('oauth', 'security', 'command') as $basename) {
             $loader->load(sprintf('%s.xml', $basename));
         }
 

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_oauth_server.command.create_client" class="FOS\OAuthServerBundle\Command\CreateClientCommand">
+            <argument type="service" id="fos_oauth_server.client_manager.default" />
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/console": "~2.1"
+        "symfony/console": "~2.1",
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/framework-bundle": "~2.2|~3.0",
         "symfony/security-bundle": "~2.1|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.3.3",
         "friendsofsymfony/oauth2-php": "~1.1.0",
         "symfony/framework-bundle": "~2.2",
-        "symfony/security-bundle": "~2.1"
+        "symfony/security-bundle": "~2.1",
+        "symfony/console": "~2.1"
     },
     "require-dev": {
         "symfony/class-loader": "~2.1",


### PR DESCRIPTION
This is a command to create a new client from the command line

```
$ app/console fos:oauth-server:create-client [--redirect-uri] [--grant-type]
```

Example

```
$ app/console fos:oauth-server:create-client --grant-type="refresh_token" --grant-type="client_credentials"
```
