### PR TITLE
Twig Function "form_enctype" is deprecated.

### DIFF
--- a/Resources/views/Authorize/authorize_content.html.twig
+++ b/Resources/views/Authorize/authorize_content.html.twig
@@ -1,4 +1,4 @@
-<form action="{{ path('fos_oauth_server_authorize') }}" method="POST" class="fos_oauth_server_authorize" {{ form_enctype(form) }}>
+{{ form_start(form, {'method': 'POST', 'action': path('fos_oauth_server_authorize'), 'label_attr': {'class': 'fos_oauth_server_authorize'} }) }}
     <input type="submit" name="accepted" value="{{ 'authorize.accept'|trans({}, 'FOSOAuthServerBundle') }}" />
     <input type="submit" name="rejected" value="{{ 'authorize.reject'|trans({}, 'FOSOAuthServerBundle') }}" />
 


### PR DESCRIPTION
I've just tested the project with `^1.5@dev` (thanks for the alias). And I only got this deprecate message.