### PR TITLE
Added test for the CleanCommand.

### DIFF
--- a/Tests/Command/CleanCommandTest.php
+++ b/Tests/Command/CleanCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Tests\Command;
+
+use FOS\OAuthServerBundle\Command\CleanCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CleanCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \FOS\OAuthServerBundle\Command\CleanCommand
+     */
+    private $command;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $command = new CleanCommand();
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $this->command = $application->find($command->getName());
+        $this->command->setContainer($this->container);
+    }
+
+    /**
+     * Delete expired tokens for classes that implement the TokenManagerInterface.
+     */
+    public function testItShouldRemoveExpiredTokensForTokenManagerInterfaces()
+    {
+        $expiredAccessTokens = 5;
+        $accessTokenManager = $this->getMock('FOS\OAuthServerBundle\Model\TokenManagerInterface');
+        $accessTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAccessTokens));
+
+        $expiredRefreshTokens = 3;
+        $refreshTokenManager = $this->getMock('FOS\OAuthServerBundle\Model\TokenManagerInterface');
+        $refreshTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredRefreshTokens));
+
+        $expiredAuthCodes = 0;
+        $authCodeManager = $this->getMock('FOS\OAuthServerBundle\Model\TokenManagerInterface');
+        $authCodeManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAuthCodes));
+
+        $containerMap = array(
+            'fos_oauth_server.access_token_manager' => $accessTokenManager,
+            'fos_oauth_server.refresh_token_manager' => $refreshTokenManager,
+            'fos_oauth_server.auth_code_manager' => $authCodeManager,
+        );
+
+        $this->container
+            ->expects($this->exactly(count($containerMap)))
+            ->method('get')
+            ->will($this->returnCallback(function ($argument) use ($containerMap) {
+                return $containerMap[$argument];
+            }));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(array('command' => $this->command->getName()));
+        $display = $tester->getDisplay();
+
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredAccessTokens, 'Access token'), $display);
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredRefreshTokens, 'Refresh token'), $display);
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredAuthCodes, 'Auth code'), $display);
+    }
+
+    /**
+     * Delete expired tokens for classes that implement the AuthCodeManagerInterface.
+     */
+    public function testItShouldRemoveExpiredTokensForAuthCodeManagerInterfaces()
+    {
+        $expiredAccessTokens = 5;
+        $accessTokenManager = $this->getMock('FOS\OAuthServerBundle\Model\AuthCodeManagerInterface');
+        $accessTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAccessTokens));
+
+        $expiredRefreshTokens = 3;
+        $refreshTokenManager = $this->getMock('FOS\OAuthServerBundle\Model\AuthCodeManagerInterface');
+        $refreshTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredRefreshTokens));
+
+        $expiredAuthCodes = 0;
+        $authCodeManager = $this->getMock('FOS\OAuthServerBundle\Model\AuthCodeManagerInterface');
+        $authCodeManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAuthCodes));
+
+        $containerMap = array(
+            'fos_oauth_server.access_token_manager' => $accessTokenManager,
+            'fos_oauth_server.refresh_token_manager' => $refreshTokenManager,
+            'fos_oauth_server.auth_code_manager' => $authCodeManager,
+        );
+
+        $this->container
+            ->expects($this->exactly(count($containerMap)))
+            ->method('get')
+            ->will($this->returnCallback(function ($argument) use ($containerMap) {
+                return $containerMap[$argument];
+            }));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(array('command' => $this->command->getName()));
+        $display = $tester->getDisplay();
+
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredAccessTokens, 'Access token'), $display);
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredRefreshTokens, 'Refresh token'), $display);
+        $this->assertRegExp(sprintf('\'Removed %d items from %s storage.\'', $expiredAuthCodes, 'Auth code'), $display);
+    }
+
+    /**
+     * Skip classes for deleting expired tokens that do not implement AuthCodeManagerInterface or TokenManagerInterface.
+     */
+    public function testItShouldNotRemoveExpiredTokensForOtherClasses()
+    {
+        $containerMap = array(
+            'fos_oauth_server.access_token_manager' => new \stdClass(),
+            'fos_oauth_server.refresh_token_manager' => new \stdClass(),
+            'fos_oauth_server.auth_code_manager' => new \stdClass(),
+        );
+
+        $this->container
+            ->expects($this->exactly(count($containerMap)))
+            ->method('get')
+            ->will($this->returnCallback(function ($argument) use ($containerMap) {
+                return $containerMap[$argument];
+            }));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(array('command' => $this->command->getName()));
+        $display = $tester->getDisplay();
+
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Access token'), $display);
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Refresh token'), $display);
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Auth code'), $display);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/class-loader": "~2.1|~3.0",
         "symfony/yaml": "~2.1|~3.0",
         "symfony/form": "~2.3|~3.0",
+        "symfony/console": "~2.1|~3.0",
         "willdurand/propel-typehintable-behavior": "^1.0.4",
         "propel/propel1": "^1.6.5",
         "phing/phing": "~2.4",
@@ -37,7 +38,8 @@
         "doctrine/mongodb-odm-bundle": "*",
         "propel/propel-bundle": "If you want to use Propel with Symfony2, then you will have to install the PropelBundle",
         "willdurand/propel-typehintable-behavior": "The Typehintable behavior is useful to add type hints on generated methods, to be compliant with interfaces",
-        "symfony/form" : "Needed to be able to use the AuthorizeFormType"
+        "symfony/form" : "Needed to be able to use the AuthorizeFormType",
+        "symfony/console": "Needed to be able to use commands"
     },
     "autoload": {
         "psr-4": { "FOS\\OAuthServerBundle\\": "" }
@@ -47,5 +49,4 @@
             "dev-master": "1.5-dev"
         }
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": "^5.3.3|^7.0",
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/framework-bundle": "~2.2|~3.0",
-        "symfony/security-bundle": "~2.1|~3.0"
+        "symfony/security-bundle": "~2.1|~3.0",
+        "symfony/dependency-injection": "^2.0.5|~3.0"
     },
     "require-dev": {
         "symfony/class-loader": "~2.1|~3.0",


### PR DESCRIPTION
- Added a test for the `CleanCommand`.
- Added `symfony/console` to dev dependencies to be able to test it.
- Added `symfony/console` to suggestions to be able to use it for users.

Might it also be an idea to add `phpunit/phpunit` as a dev dependency for testing purposes?