### PR TITLE
Adding missing ODM mappings to docs

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -320,6 +320,7 @@ class AuthCode extends BaseAuthCode
 {
     protected $id;
     protected $client;
+    protected $user;
 
     public function getClient()
     {
@@ -344,6 +345,7 @@ class AuthCode extends BaseAuthCode
     <document name="Acme\ApiBundle\Document\AuthCode" db="acme" collection="oauthAuthCode" customId="true">
         <field fieldName="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
+        <reference-one target-document="Acme\ApiBundle\Document\User" field="user" />
     </document>
 
 </doctrine-mongo-mapping>
@@ -363,6 +365,7 @@ class AccessToken extends BaseAccessToken
 {
     protected $id;
     protected $client;
+    protected $user;
 
     public function getClient()
     {
@@ -387,6 +390,7 @@ class AccessToken extends BaseAccessToken
     <document name="Acme\ApiBundle\Document\AccessToken" db="acme" collection="oauthAccessToken" customId="true">
         <field fieldName="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
+        <reference-one target-document="Acme\ApiBundle\Document\User" field="user" />
     </document>
 
 </doctrine-mongo-mapping>
@@ -406,6 +410,7 @@ class RefreshToken extends BaseRefreshToken
 {
     protected $id;
     protected $client;
+    protected $user;
 
     public function getClient()
     {
@@ -430,6 +435,7 @@ class RefreshToken extends BaseRefreshToken
     <document name="Acme\ApiBundle\Document\RefreshToken" db="acme" collection="oauthRefreshToken" customId="true">
         <field fieldName="id" id="true" strategy="AUTO" />
         <reference-one target-document="Acme\ApiBundle\Document\Client" field="client" />
+        <reference-one target-document="Acme\ApiBundle\Document\User" field="user" />
     </document>
 
 </doctrine-mongo-mapping>


### PR DESCRIPTION
With the current documentation, when authenticating with username/password, the user is not linked to the access token. I've seen the the user property is defined, but not mapped.
