### PR TITLE
Repository is now instanciated on the fly

### DIFF
--- a/Document/AuthCodeManager.php
+++ b/Document/AuthCodeManager.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FOS\OAuthServerBundle\Document;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\DocumentRepository;
 use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManager as BaseAuthCodeManager;
 
@@ -26,23 +25,13 @@ class AuthCodeManager extends BaseAuthCodeManager
     protected $dm;
 
     /**
-     * @var DocumentRepository
-     */
-    protected $repository;
-
-    /**
      * @var string
      */
     protected $class;
 
     public function __construct(DocumentManager $dm, $class)
     {
-        // NOTE: bug in Doctrine, hinting DocumentRepository|ObjectRepository when only DocumentRepository is expected
-        /** @var DocumentRepository $repository */
-        $repository = $dm->getRepository($class);
-
         $this->dm = $dm;
-        $this->repository = $repository;
         $this->class = $class;
     }
 
@@ -59,7 +48,7 @@ class AuthCodeManager extends BaseAuthCodeManager
      */
     public function findAuthCodeBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->dm->getRepository($this->class)->findOneBy($criteria);
     }
 
     /**
@@ -85,8 +74,10 @@ class AuthCodeManager extends BaseAuthCodeManager
      */
     public function deleteExpired()
     {
-        $result = $this
-            ->repository
+        /** @var \Doctrine\ODM\MongoDB\DocumentRepository $repository */
+        $repository = $this->dm->getRepository($this->class);
+
+        $result = $repository
             ->createQueryBuilder()
             ->remove()
             ->field('expiresAt')->lt(time())

--- a/Document/ClientManager.php
+++ b/Document/ClientManager.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FOS\OAuthServerBundle\Document;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\DocumentRepository;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManager as BaseClientManager;
 
@@ -26,23 +25,13 @@ class ClientManager extends BaseClientManager
     protected $dm;
 
     /**
-     * @var DocumentRepository
-     */
-    protected $repository;
-
-    /**
      * @var string
      */
     protected $class;
 
     public function __construct(DocumentManager $dm, $class)
     {
-        // NOTE: bug in Doctrine, hinting DocumentRepository|ObjectRepository when only DocumentRepository is expected
-        /** @var DocumentRepository $repository */
-        $repository = $dm->getRepository($class);
-
         $this->dm = $dm;
-        $this->repository = $repository;
         $this->class = $class;
     }
 
@@ -59,7 +48,7 @@ class ClientManager extends BaseClientManager
      */
     public function findClientBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->dm->getRepository($this->class)->findOneBy($criteria);
     }
 
     /**

--- a/Document/TokenManager.php
+++ b/Document/TokenManager.php
@@ -26,23 +26,13 @@ class TokenManager extends BaseTokenManager
     protected $dm;
 
     /**
-     * @var DocumentRepository
-     */
-    protected $repository;
-
-    /**
      * @var string
      */
     protected $class;
 
     public function __construct(DocumentManager $dm, $class)
     {
-        // NOTE: bug in Doctrine, hinting DocumentRepository|ObjectRepository when only DocumentRepository is expected
-        /** @var DocumentRepository $repository */
-        $repository = $dm->getRepository($class);
-
         $this->dm = $dm;
-        $this->repository = $repository;
         $this->class = $class;
     }
 
@@ -59,7 +49,7 @@ class TokenManager extends BaseTokenManager
      */
     public function findTokenBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->dm->getRepository($this->class)->findOneBy($criteria);
     }
 
     /**
@@ -85,8 +75,10 @@ class TokenManager extends BaseTokenManager
      */
     public function deleteExpired()
     {
-        $result = $this
-            ->repository
+        // NOTE: bug in Doctrine, hinting DocumentRepository|ObjectRepository when only DocumentRepository is expected
+        /** @var DocumentRepository $repository */
+        $repository = $this->dm->getRepository($this->class);
+        $result = $repository
             ->createQueryBuilder()
             ->remove()
             ->field('expiresAt')->lt(time())

--- a/Entity/ClientManager.php
+++ b/Entity/ClientManager.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FOS\OAuthServerBundle\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManager as BaseClientManager;
 
@@ -26,23 +25,13 @@ class ClientManager extends BaseClientManager
     protected $em;
 
     /**
-     * @var EntityRepository
-     */
-    protected $repository;
-
-    /**
      * @var string
      */
     protected $class;
 
     public function __construct(EntityManagerInterface $em, $class)
     {
-        // NOTE: bug in Doctrine, hinting EntityRepository|ObjectRepository when only EntityRepository is expected
-        /** @var EntityRepository $repository */
-        $repository = $em->getRepository($class);
-
         $this->em = $em;
-        $this->repository = $repository;
         $this->class = $class;
     }
 
@@ -59,7 +48,7 @@ class ClientManager extends BaseClientManager
      */
     public function findClientBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->em->getRepository($this->class)->findOneBy($criteria);
     }
 
     /**

--- a/Entity/TokenManager.php
+++ b/Entity/TokenManager.php
@@ -26,23 +26,13 @@ class TokenManager extends BaseTokenManager
     protected $em;
 
     /**
-     * @var EntityRepository
-     */
-    protected $repository;
-
-    /**
      * @var string
      */
     protected $class;
 
     public function __construct(EntityManagerInterface $em, $class)
     {
-        // NOTE: bug in Doctrine, hinting EntityRepository|ObjectRepository when only EntityRepository is expected
-        /** @var EntityRepository $repository */
-        $repository = $em->getRepository($class);
-
         $this->em = $em;
-        $this->repository = $repository;
         $this->class = $class;
     }
 
@@ -59,7 +49,7 @@ class TokenManager extends BaseTokenManager
      */
     public function findTokenBy(array $criteria)
     {
-        return $this->repository->findOneBy($criteria);
+        return $this->em->getRepository($this->class)->findOneBy($criteria);
     }
 
     /**
@@ -85,7 +75,10 @@ class TokenManager extends BaseTokenManager
      */
     public function deleteExpired()
     {
-        $qb = $this->repository->createQueryBuilder('t');
+        // NOTE: bug in Doctrine, hinting EntityRepository|ObjectRepository when only EntityRepository is expected
+        /** @var EntityRepository $repository */
+        $repository = $this->em->getRepository($this->class);
+        $qb = $repository->createQueryBuilder('t');
         $qb
             ->delete()
             ->where('t.expiresAt < ?1')

--- a/Tests/Document/AuthCodeManagerTest.php
+++ b/Tests/Document/AuthCodeManagerTest.php
@@ -65,13 +65,6 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         ;
         $this->className = 'TestClassName'.\random_bytes(5);
 
-        $this->documentManager
-            ->expects($this->once())
-            ->method('getRepository')
-            ->with($this->className)
-            ->willReturn($this->repository)
-        ;
-
         $this->instance = new AuthCodeManager($this->documentManager, $this->className);
 
         parent::setUp();
@@ -94,6 +87,13 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $criteria = [
             \random_bytes(10),
         ];
+
+        $this->documentManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $this->repository
             ->expects($this->once())
@@ -155,6 +155,13 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteExpired()
     {
+        $this->documentManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
+
         $queryBuilder = $this->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock()

--- a/Tests/Document/ClientManagerTest.php
+++ b/Tests/Document/ClientManagerTest.php
@@ -61,13 +61,6 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         ;
         $this->className = 'RandomClassName'.\random_bytes(5);
 
-        $this->documentManager
-            ->expects($this->once())
-            ->method('getRepository')
-            ->with($this->className)
-            ->willReturn($this->repository)
-        ;
-
         $this->instance = new ClientManager($this->documentManager, $this->className);
 
         parent::setUp();
@@ -76,7 +69,6 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
     public function testConstructWillSetParameters()
     {
         $this->assertAttributeSame($this->documentManager, 'dm', $this->instance);
-        $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
@@ -91,6 +83,13 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         $criteria = [
             \random_bytes(5),
         ];
+
+        $this->documentManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $this->repository
             ->expects($this->once())

--- a/Tests/Document/TokenManagerTest.php
+++ b/Tests/Document/TokenManagerTest.php
@@ -65,13 +65,6 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
             ->getMock()
         ;
 
-        $this->documentManager
-            ->expects($this->once())
-            ->method('getRepository')
-            ->with($this->className)
-            ->willReturn($this->repository)
-        ;
-
         $this->instance = new TokenManager($this->documentManager, $this->className);
     }
 
@@ -79,6 +72,13 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
     {
         $randomToken = \random_bytes(5);
         $randomResult = \random_bytes(5);
+
+        $this->documentManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $this->repository
             ->expects($this->once())
@@ -145,6 +145,13 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteExpired()
     {
+        $this->documentManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
+
         $queryBuilder = $this->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock()

--- a/Tests/Entity/ClientManagerTest.php
+++ b/Tests/Entity/ClientManagerTest.php
@@ -57,13 +57,6 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         ;
         $this->className = 'RandomClassName'.\random_bytes(5);
 
-        $this->entityManager
-            ->expects($this->once())
-            ->method('getRepository')
-            ->with($this->className)
-            ->willReturn($this->repository)
-        ;
-
         $this->instance = new ClientManager($this->entityManager, $this->className);
 
         parent::setUp();
@@ -72,7 +65,6 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
     public function testConstructWillSetParameters()
     {
         $this->assertAttributeSame($this->entityManager, 'em', $this->instance);
-        $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
@@ -87,6 +79,13 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
             \random_bytes(5),
         ];
         $randomResult = \random_bytes(5);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $this->repository
             ->expects($this->once())

--- a/Tests/Entity/TokenManagerTest.php
+++ b/Tests/Entity/TokenManagerTest.php
@@ -63,20 +63,12 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
             ->getMock()
         ;
 
-        $this->entityManager
-            ->expects($this->once())
-            ->method('getRepository')
-            ->with($this->className)
-            ->willReturn($this->repository)
-        ;
-
         $this->instance = new TokenManager($this->entityManager, $this->className);
     }
 
     public function testConstructWillSetParameters()
     {
         $this->assertAttributeSame($this->entityManager, 'em', $this->instance);
-        $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
@@ -111,6 +103,13 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $criteria = [
             \random_bytes(5),
         ];
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $this->repository
             ->expects($this->once())
@@ -173,6 +172,13 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
     public function testDeleteExpired()
     {
         $randomResult = \random_bytes(10);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($this->className)
+            ->willReturn($this->repository)
+        ;
 
         $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
No more repository instantiated in constructor of ClientManager and TokenManager.

This avoids a database connection to be established for every request.

Fixes issue https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/issues/422