### PR TITLE
Fixed Propel undefined use

### DIFF
--- a/Propel/Client.php
+++ b/Propel/Client.php
@@ -11,7 +11,7 @@
 
 namespace FOS\OAuthServerBundle\Propel;
 
-use FOS\OAuthServerBundle\Propel\om\BaseClient;
+use FOS\OAuthServerBundle\Model\Client as BaseClient;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Util\Random;
 use OAuth2\OAuth2;


### PR DESCRIPTION
That was causing an internal server error in a case where I was using another Client class without the correct or missing use.