### PR TITLE
Add a "create client" command

### DIFF
--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Command;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+class CreateClientCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:oauth-server:create-client')
+            ->setDescription('Creates a new client')
+            ->addOption(
+                'redirect-uri',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Sets redirect uri for client. Use this option multiple times to set multiple redirect URIs.',
+                null
+            )
+            ->addOption(
+                'grant-type',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Sets allowed grant type for client. Use this option multiple times to set multiple grant types..',
+                null
+            )
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command creates a new client.
+
+<info>php %command.full_name% [--redirect-uri=...] [--grant-type=...]</info>
+
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Client Credentials');
+
+        // Get the client manager
+        $clientManager = $this->getContainer()->get('fos_oauth_server.client_manager.default');
+
+        // Create a new client
+        $client = $clientManager->createClient();
+
+        $client->setRedirectUris($input->getOption('redirect-uri'));
+        $client->setAllowedGrantTypes($input->getOption('grant-type'));
+
+        // Save the client
+        $clientManager->updateClient($client);
+
+        // Give the credentials back to the user
+        $headers = ['Client ID', 'Client Secret'];
+        $rows = [
+            [$client->getPublicId(), $client->getSecret()],
+        ];
+
+        $io->table($headers, $rows);
+
+        return 0;
+    }
+}

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -566,6 +566,16 @@ fos_oauth_server:
 
 ## Creating A Client
 
+### Console Command
+
+The most convenient way to create a client is to use the console command.
+
+    $ php app/console fos:oauth-server:create-client --redirect-uri="..." --grant-type="..."
+    
+Note: you can use `--redirect-uri` and `--grant-type` multiple times to add additional values.
+
+### Programatically
+
 Before you can generate tokens, you need to create a Client using the ClientManager.
 
 ``` php

--- a/Tests/Command/CreateClientCommandTest.php
+++ b/Tests/Command/CreateClientCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Tests\Command;
+
+use FOS\OAuthServerBundle\Command\CreateClientCommand;
+use FOS\OAuthServerBundle\Tests\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+
+class CreateClientCommandTest extends TestCase
+{
+    /**
+     * @var
+     */
+    private $command;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $command = new CreateClientCommand();
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->container = new Container();
+
+        $this->command = $application->find($command->getName());
+        $this->command->setContainer($this->container);
+    }
+
+    /**
+     * @dataProvider classProvider
+     *
+     * @param string $class A fully qualified class name.
+     */
+    public function testItShouldCreateClient($clientManager, $client)
+    {
+        $clientManager = $this
+            ->getMockBuilder($clientManager)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $clientManager
+            ->expects($this->any())
+            ->method('createClient')
+            ->will($this->returnValue(new $client));
+
+        $this->container->set('fos_oauth_server.client_manager.default', $clientManager);
+
+        $commandTester = new CommandTester($this->command);
+
+        $commandTester->execute([
+            'command' => $this->command->getName(),
+            '--redirect-uri' => ['https://www.example.com/oauth2/callback'],
+            '--grant-type' => [
+                'authorization_code',
+                'password',
+                'refresh_token',
+                'token',
+                'client_credentials',
+            ],
+        ]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertContains('Client ID', $output);
+        $this->assertContains('Client Secret', $output);
+    }
+
+    /**
+     * @return array
+     */
+    public function classProvider()
+    {
+        return [
+            ['FOS\OAuthServerBundle\Document\ClientManager', 'FOS\OAuthServerBundle\Document\Client'],
+            ['FOS\OAuthServerBundle\Entity\ClientManager', 'FOS\OAuthServerBundle\Entity\Client'],
+            ['FOS\OAuthServerBundle\Model\ClientManager', 'FOS\OAuthServerBundle\Model\Client'],
+            ['FOS\OAuthServerBundle\Propel\ClientManager', 'FOS\OAuthServerBundle\Propel\Client'],
+        ];
+    }
+}


### PR DESCRIPTION
In response to #452 and a personal desire to stop re-writing this command in every application I build, I present to you, a create-client console command (including some basic documentation!).

Example Output:
![image](https://user-images.githubusercontent.com/3661151/33143794-f06fe62c-cf88-11e7-822e-3d51c338ae70.png)

I started to add an output format option/argument, but I don't know whether it would have been useful. Let me know what you think (and/or if I need to make changes).