### PR TITLE
Fixes to the security doc to make it compatible with sf3

### DIFF
--- a/Resources/doc/a_note_about_security.md
+++ b/Resources/doc/a_note_about_security.md
@@ -17,21 +17,21 @@ In the `loginAction()` of your `SecurityController`, just add few lines before t
 namespace Acme\SecurityBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Security;
 
 class SecurityController extends Controller
 {
-    public function loginAction()
+    public function loginAction(Request $request)
     {
-        $request = $this->getRequest();
         $session = $request->getSession();
 
         // get the login error if there is one
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
         } else {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+            $error = $session->get(Security::AUTHENTICATION_ERROR);
+            $session->remove(Security::AUTHENTICATION_ERROR);
         }
 
         // Add the following lines
@@ -43,7 +43,7 @@ class SecurityController extends Controller
 
         return $this->render('AcmeSecurityBundle:Security:login.html.twig', array(
             // last username entered by the user
-            'last_username' => $session->get(SecurityContext::LAST_USERNAME),
+            'last_username' => $session->get(Security::LAST_USERNAME),
             'error'         => $error,
         ));
     }


### PR DESCRIPTION
Symfony 2.6 deprecates the SecurityContext and Symfony 3.x eliminates it, rendering the sample code useless. I have adapted the example and applied the necessary fixes.

