### PR TITLE
Using random_bytes() to generate a random token

### DIFF
--- a/Tests/Util/RandomTest.php
+++ b/Tests/Util/RandomTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FOS\OAuthServerBundle\Tests\Util;
+
+use FOS\OAuthServerBundle\Util\Random;
+use phpmock\phpunit\PHPMock;
+
+/**
+ * Class RandomTest
+ *
+ * @author Nikola Petkanski <nikola@petkanski.com
+ */
+class RandomTest extends \PHPUnit_Framework_TestCase
+{
+    use PHPMock;
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGenerateTokenWillUseRandomBytesIfAvailable()
+    {
+        $hashResult = \random_bytes(32);
+
+        $this->getFunctionMock('FOS\OAuthServerBundle\Util', 'random_bytes')
+            ->expects($this->once())
+            ->with(32)
+            ->willReturn($hashResult)
+        ;
+
+        $bin2hexResult = \bin2hex($hashResult);
+        $this->getFunctionMock('FOS\OAuthServerBundle\Util', 'bin2hex')
+            ->expects($this->once())
+            ->with($hashResult)
+            ->willReturn($bin2hexResult)
+        ;
+
+        $baseConvertResult = \base_convert($bin2hexResult, 16, 36);
+        $this->getFunctionMock('FOS\OAuthServerBundle\Util', 'base_convert')
+            ->expects($this->once())
+            ->with($bin2hexResult, 16, 36)
+            ->willReturn($baseConvertResult)
+        ;
+
+        $this->assertSame($baseConvertResult, Random::generateToken());
+    }
+}

--- a/Util/Random.php
+++ b/Util/Random.php
@@ -11,23 +11,16 @@
 
 namespace FOS\OAuthServerBundle\Util;
 
+/**
+ * Class Random
+ *
+ * @author Nikola Petkanski <nikola@petkanski.com
+ */
 class Random
 {
     public static function generateToken()
     {
-        $bytes = false;
-        if (function_exists('openssl_random_pseudo_bytes') && 0 !== stripos(PHP_OS, 'win')) {
-            $bytes = openssl_random_pseudo_bytes(32, $strong);
-
-            if (true !== $strong) {
-                $bytes = false;
-            }
-        }
-
-        // let's just hope we got a good seed
-        if (false === $bytes) {
-            $bytes = hash('sha256', uniqid(mt_rand(), true), true);
-        }
+        $bytes = random_bytes(32);
 
         return base_convert(bin2hex($bytes), 16, 36);
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/framework-bundle": "~2.8|~3.0|^4.0",
         "symfony/security-bundle": "~2.8|~3.0|^4.0",
-        "symfony/dependency-injection": "^2.8|~3.0|^4.0"
+        "symfony/dependency-injection": "^2.8|~3.0|^4.0",
+        "paragonie/random_compat": "^1|^2"
     },
     "require-dev": {
         "symfony/class-loader": "~2.8|~3.0|^4.0",
@@ -35,7 +36,8 @@
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/orm": "~2.2",
         "phpunit/phpunit": "~4.8|~5.0",
-        "symfony/phpunit-bridge": "~2.8|~3.0|^4.0"
+        "symfony/phpunit-bridge": "~2.8|~3.0|^4.0",
+        "php-mock/php-mock-phpunit": "^1.1"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "*",


### PR DESCRIPTION
Changes:

- No longer having different unique hash strategies across platforms - we are now using random_bytes(). It has been introduced in PHP 7.x, but has been available as a user-land polyfill for a long time.
- added unit test 

Fixes:
- #515 

Added dependencies:
- `paragonie/random_compat` - `random_bytes()` and `random_int()` PHP 5.x polyfill that is already required by `symfony/polyfill-php70`.
- `php-mock/php-mock-phpunit` - useful for mocking php functions in a given namespace. https://github.com/php-mock/php-mock-phpunit