### PR TITLE
Allow template overrides in sf >= 3.4

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -195,7 +195,7 @@ class AuthorizeController implements ContainerAwareInterface
         }
 
         return $this->templating->renderResponse(
-            'FOSOAuthServerBundle:Authorize:authorize.html.'.$this->templateEngineType,
+            '@FOSOAuthServerBundle:Authorize:authorize.html.'.$this->templateEngineType,
             [
                 'form' => $form->createView(),
                 'client' => $this->getClient(),

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -195,7 +195,7 @@ class AuthorizeController implements ContainerAwareInterface
         }
 
         return $this->templating->renderResponse(
-            '@FOSOAuthServerBundle:Authorize:authorize.html.'.$this->templateEngineType,
+            '@FOSOAuthServer/Authorize/authorize.html.'.$this->templateEngineType,
             [
                 'form' => $form->createView(),
                 'client' => $this->getClient(),

--- a/Resources/views/Authorize/authorize.html.twig
+++ b/Resources/views/Authorize/authorize.html.twig
@@ -1,5 +1,5 @@
-{% extends "@FOSOAuthServerBundle::layout.html.twig" %}
+{% extends "@FOSOAuthServer/layout.html.twig" %}
 
 {% block fos_oauth_server_content %}
-{% include "@FOSOAuthServerBundle:Authorize:authorize_content.html.twig" %}
+{% include "@FOSOAuthServer/Authorize/authorize_content.html.twig" %}
 {% endblock fos_oauth_server_content %}

--- a/Resources/views/Authorize/authorize.html.twig
+++ b/Resources/views/Authorize/authorize.html.twig
@@ -1,5 +1,5 @@
-{% extends "FOSOAuthServerBundle::layout.html.twig" %}
+{% extends "@FOSOAuthServerBundle::layout.html.twig" %}
 
 {% block fos_oauth_server_content %}
-{% include "FOSOAuthServerBundle:Authorize:authorize_content.html.twig" %}
+{% include "@FOSOAuthServerBundle:Authorize:authorize_content.html.twig" %}
 {% endblock fos_oauth_server_content %}

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -313,7 +313,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             ->expects($this->at(0))
             ->method('renderResponse')
             ->with(
-                'FOSOAuthServerBundle:Authorize:authorize.html.twig',
+                '@FOSOAuthServer/Authorize/authorize.html.twig',
                 [
                     'form' => $this->formView,
                     'client' => $this->client,
@@ -472,7 +472,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             ->expects($this->at(0))
             ->method('renderResponse')
             ->with(
-                'FOSOAuthServerBundle:Authorize:authorize.html.twig',
+                '@FOSOAuthServer/Authorize/authorize.html.twig',
                 [
                     'form' => $this->formView,
                     'client' => $this->client,


### PR DESCRIPTION
Without the `@` symbol, symfony templating will look in the `__main__` namespace, rather than `FOSOAuthServerBundle`.