### PR TITLE
Make service client manager public

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="fos_oauth_server.client_manager.default" class="FOS\OAuthServerBundle\Entity\ClientManager">
+        <service id="fos_oauth_server.client_manager.default" public="true" class="FOS\OAuthServerBundle\Entity\ClientManager">
             <argument type="service" id="fos_oauth_server.entity_manager" />
             <argument>%fos_oauth_server.model.client.class%</argument>
         </service>


### PR DESCRIPTION
 `fos_oauth_server.client_manager.default` should be public by default, Symfony 4 #529