### PR TITLE
Update AuthorizeController.php

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -22,7 +22,7 @@ use OAuth2\OAuth2ServerException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -133,7 +133,7 @@ class AuthorizeController implements ContainerAwareInterface
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $router,
         ClientManagerInterface $clientManager,
-        EventDispatcher $eventDispatcher,
+        EventDispatcherInterface $eventDispatcher,
         $templateEngineType = 'twig'
     ) {
         $this->requestStack = $requestStack;

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -101,7 +101,7 @@ class AuthorizeController implements ContainerAwareInterface
     private $templateEngineType;
 
     /**
-     * @var EventDispatcher
+     * @var EventDispatcherInterface
      */
     private $eventDispatcher;
 
@@ -120,7 +120,7 @@ class AuthorizeController implements ContainerAwareInterface
      * @param TokenStorageInterface  $tokenStorage
      * @param UrlGeneratorInterface  $router
      * @param ClientManagerInterface $clientManager
-     * @param EventDispatcher        $eventDispatcher
+     * @param EventDispatcherInterface        $eventDispatcher
      * @param string                 $templateEngineType
      */
     public function __construct(


### PR DESCRIPTION
in dev mode (SF 3.4.4) Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher is passed to arg 10 constructor whereas Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher is passed in prod mode, so Interface Class Symfony\Component\EventDispatcher\EventDispatcherInterface is required