### PR TITLE
Use EventDispatcherInterface

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -22,7 +22,7 @@ use OAuth2\OAuth2ServerException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -101,7 +101,7 @@ class AuthorizeController implements ContainerAwareInterface
     private $templateEngineType;
 
     /**
-     * @var EventDispatcher
+     * @var EventDispatcherInterface
      */
     private $eventDispatcher;
 
@@ -111,17 +111,17 @@ class AuthorizeController implements ContainerAwareInterface
      *
      * @todo This controller could be refactored to do not rely on so many dependencies
      *
-     * @param RequestStack           $requestStack
-     * @param SessionInterface       $session
-     * @param Form                   $authorizeForm
-     * @param AuthorizeFormHandler   $authorizeFormHandler
-     * @param OAuth2                 $oAuth2Server
-     * @param EngineInterface        $templating
-     * @param TokenStorageInterface  $tokenStorage
-     * @param UrlGeneratorInterface  $router
-     * @param ClientManagerInterface $clientManager
-     * @param EventDispatcher        $eventDispatcher
-     * @param string                 $templateEngineType
+     * @param RequestStack             $requestStack
+     * @param SessionInterface         $session
+     * @param Form                     $authorizeForm
+     * @param AuthorizeFormHandler     $authorizeFormHandler
+     * @param OAuth2                   $oAuth2Server
+     * @param EngineInterface          $templating
+     * @param TokenStorageInterface    $tokenStorage
+     * @param UrlGeneratorInterface    $router
+     * @param ClientManagerInterface   $clientManager
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param string                   $templateEngineType
      */
     public function __construct(
         RequestStack $requestStack,
@@ -133,7 +133,7 @@ class AuthorizeController implements ContainerAwareInterface
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $router,
         ClientManagerInterface $clientManager,
-        EventDispatcher $eventDispatcher,
+        EventDispatcherInterface $eventDispatcher,
         $templateEngineType = 'twig'
     ) {
         $this->requestStack = $requestStack;

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -20,7 +20,7 @@ use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use OAuth2\OAuth2;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -82,7 +82,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
     protected $clientManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcher
+     * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcherInterface
      */
     protected $eventDispatcher;
 
@@ -169,7 +169,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $this->eventDispatcher = $this->getMockBuilder(EventDispatcher::class)
+        $this->eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;


### PR DESCRIPTION
Using `EventDispatcher` throws an exception on sf >= 3.4 in when the debugger is enabled, as the debugger wraps the `EventDispatcher` with `Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher`.