### PR TITLE
While testing unauthorized access to API on Symfony4 I got an error.

### DIFF
--- a/Security/Authentication/Provider/OAuthProvider.php
+++ b/Security/Authentication/Provider/OAuthProvider.php
@@ -17,6 +17,7 @@ use FOS\OAuthServerBundle\Security\Authentication\Token\OAuthToken;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2AuthenticateException;
 use OAuth2\OAuth2ServerException;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
@@ -85,7 +86,7 @@ class OAuthProvider implements AuthenticationProviderInterface
                         $this->userChecker->checkPreAuth($user);
                     } catch (AccountStatusException $e) {
                         throw new OAuth2AuthenticateException(
-                            OAuth2::HTTP_UNAUTHORIZED,
+                            Response::HTTP_UNAUTHORIZED,
                             OAuth2::TOKEN_TYPE_BEARER,
                             $this->serverService->getVariable(OAuth2::CONFIG_WWW_REALM),
                             'access_denied',
@@ -115,7 +116,7 @@ class OAuthProvider implements AuthenticationProviderInterface
                         $this->userChecker->checkPostAuth($user);
                     } catch (AccountStatusException $e) {
                         throw new OAuth2AuthenticateException(
-                            OAuth2::HTTP_UNAUTHORIZED,
+                            Response::HTTP_UNAUTHORIZED,
                             OAuth2::TOKEN_TYPE_BEARER,
                             $this->serverService->getVariable(OAuth2::CONFIG_WWW_REALM),
                             'access_denied',

--- a/Security/EntryPoint/OAuthEntryPoint.php
+++ b/Security/EntryPoint/OAuthEntryPoint.php
@@ -16,6 +16,7 @@ namespace FOS\OAuthServerBundle\Security\EntryPoint;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2AuthenticateException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
@@ -31,7 +32,7 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
     public function start(Request $request, AuthenticationException $authException = null)
     {
         $exception = new OAuth2AuthenticateException(
-            OAuth2::HTTP_UNAUTHORIZED,
+            Response::HTTP_UNAUTHORIZED,
             OAuth2::TOKEN_TYPE_BEARER,
             $this->serverService->getVariable(OAuth2::CONFIG_WWW_REALM),
             'access_denied',

--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -27,6 +27,7 @@ use OAuth2\IOAuth2RefreshTokens;
 use OAuth2\Model\IOAuth2Client;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -256,7 +257,7 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
     public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders)
     {
         if (!isset($this->grantExtensions[$uri])) {
-            throw new OAuth2ServerException(OAuth2::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
+            throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
         }
 
         $grantExtension = $this->grantExtensions[$uri];


### PR DESCRIPTION
```
A non well formed numeric value encountered

/sl/vendor/symfony/http-foundation/Response.php:193
/sl/vendor/friendsofsymfony/oauth2-php/lib/OAuth2ServerException.php:72
/sl/vendor/friendsofsymfony/oauth-server-bundle/Security/EntryPoint/OAuthEntryPoint.php:41
/sl/vendor/symfony/security/Http/Firewall/ExceptionListener.php:194
/sl/vendor/symfony/security/Http/Firewall/ExceptionListener.php:108
/sl/vendor/symfony/security/Http/Firewall/ExceptionListener.php:92
/sl/vendor/symfony/event-dispatcher/EventDispatcher.php:212
/sl/vendor/symfony/event-dispatcher/EventDispatcher.php:44
/sl/vendor/symfony/http-kernel/HttpKernel.php:219
/sl/vendor/symfony/http-kernel/HttpKernel.php:77
/sl/vendor/symfony/http-kernel/Kernel.php:190
/sl/vendor/symfony/http-kernel/Client.php:68
/sl/vendor/symfony/framework-bundle/Client.php:131
/sl/vendor/symfony/browser-kit/Client.php:312
/sl/tests/Client.php:26
/sl/tests/Client.php:38
/sl/tests/Functional/Api/Controller/GetUsersControllerTest.php:24
```