### PR TITLE
Ensure logout after pre-auth event authorization

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -165,6 +165,11 @@ class AuthorizeController
         );
 
         if ($event->isAuthorizedClient()) {
+            if ($this->session && true === $this->session->get('_fos_oauth_server.ensure_logout')) {
+                $this->tokenStorage->setToken(null);
+                $this->session->invalidate();
+            }
+
             $scope = $request->get('scope', null);
 
             return $this->oAuth2Server->finishClientAuthorization(true, $user, $request, $scope);


### PR DESCRIPTION
The [Security Doc](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/blob/master/Resources/doc/a_note_about_security.md) recommends to set the `_fos_oauth_server.ensure_logout`  to true to log out after the authentication process.

But if the `PRE_AUTHORIZATION_PROCESS` event authorizes the client, the session is never invalidated.

This PR ensures the `_fos_oauth_server.ensure_logout` session parameter is correctly processed if it is set to true.