### PR TITLE
Fix error DependancyInjection Exception

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -27,7 +27,7 @@
             <argument type="service" id="fos_oauth_server.server" />
         </service>
 
-        <service id="fos_oauth_server.controller.token" alias="FOS\OAuthServerBundle\Controller\TokenController" public="true" />
+        <service id="fos_oauth_server.controller.token" class="FOS\OAuthServerBundle\Controller\TokenController" public="true" />
 
         <service id="fos_oauth_server.clean_command" class="FOS\OAuthServerBundle\Command\CleanCommand">
             <argument type="service" id="fos_oauth_server.access_token_manager" />

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -23,11 +23,11 @@
             <argument>%fos_oauth_server.server.options%</argument>
         </service>
 
-        <service id="FOS\OAuthServerBundle\Controller\TokenController">
+        <service id="FOS\OAuthServerBundle\Controller\TokenController" class="FOS\OAuthServerBundle\Controller\TokenController">
             <argument type="service" id="fos_oauth_server.server" />
         </service>
 
-        <service id="fos_oauth_server.controller.token" class="FOS\OAuthServerBundle\Controller\TokenController" public="true" />
+        <service id="fos_oauth_server.controller.token" alias="FOS\OAuthServerBundle\Controller\TokenController" public="true" />
 
         <service id="fos_oauth_server.clean_command" class="FOS\OAuthServerBundle\Command\CleanCommand">
             <argument type="service" id="fos_oauth_server.access_token_manager" />


### PR DESCRIPTION
I changed alias to class because Symfony retraces an Injection dependency error :
[Symfony\Component\DependencyInjection\Exception\RuntimeException]                                                                                                                                      
  The definition for "fos\oauthserverbundle\controller\tokencontroller" has no class. If you intend to inject this service dynamically at runtime, please mark it as synthetic=true. If this is an abstr  
  act definition solely used by child definitions, please add abstract=true, otherwise specify a class to get rid of this error.