### PR TITLE
Allow array in supported_scopes option

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -249,7 +249,7 @@ class AuthorizeController implements ContainerAwareInterface
     }
 
     /**
-     * @return ClientInterface.
+     * @return ClientInterface
      */
     protected function getClient()
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -104,7 +104,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('options')
                                 ->useAttributeAsKey('key')
                                 ->treatNullLike([])
-                                ->prototype('scalar')->end()
+                                ->prototype('variable')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -52,8 +52,8 @@ class FOSOAuthServerExtension extends Extension
         }
 
         $options = $config['service']['options'];
-        if (!empty($options['supported_scopes'])) {
-            $options['supported_scopes'] = str_replace("\n", ' ', $options['supported_scopes']);
+        if (is_array($options['supported_scopes'] ?? null)) {
+            $options['supported_scopes'] = implode(' ', $options['supported_scopes']);
         }
         $container->setParameter('fos_oauth_server.server.options', $options);
 

--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -51,7 +51,11 @@ class FOSOAuthServerExtension extends Extension
             $container->setAlias('fos_oauth_server.user_provider', new Alias($config['service']['user_provider'], false));
         }
 
-        $container->setParameter('fos_oauth_server.server.options', $config['service']['options']);
+        $options = $config['service']['options'];
+        if (!empty($options['supported_scopes'])) {
+            $options['supported_scopes'] = str_replace("\n", ' ', $options['supported_scopes']);
+        }
+        $container->setParameter('fos_oauth_server.server.options', $options);
 
         $this->remapParametersNamespaces($config, $container, [
             '' => [

--- a/Resources/doc/dealing_with_scopes.md
+++ b/Resources/doc/dealing_with_scopes.md
@@ -18,8 +18,22 @@ To configure allowed scopes in your application, you have to edit your `app/conf
 fos_oauth_server:
     service:
         options:
+            supported_scopes:
+              - scope1
+              - scope2
+              - scope3
+              - scope4
+```
+
+If you have a short list of scopes, you can define them as a simple string:
+``` yaml
+# app/config/config.yml
+fos_oauth_server:
+    service:
+        options:
             supported_scopes: scope1 scope2
 ```
+
 
 Now, clients will be able to pass a `scope` parameter when they request an access token.
 

--- a/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
+++ b/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
@@ -71,13 +71,9 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testMultilineScopes()
+    public function testStringSupportedScopes()
     {
-        $scopes = <<<'SCOPES'
-scope1
-scope2
-scope3 scope4
-SCOPES;
+        $scopes = 'scope1 scope2 scope3 scope4';
 
         $config = [
             'db_driver' => 'orm',
@@ -91,12 +87,44 @@ SCOPES;
                 ],
             ],
         ];
+
         $instance = new FOSOAuthServerExtension();
         $instance->load([$config], $this->container);
 
         $this->assertSame(
             $this->container->getParameter('fos_oauth_server.server.options'),
-            ['supported_scopes' => 'scope1 scope2 scope3 scope4']
+            [
+                'supported_scopes' => 'scope1 scope2 scope3 scope4',
+            ]
+        );
+    }
+
+    public function testArraySupportedScopes()
+    {
+        $scopes = ['scope1', 'scope2', 'scope3', 'scope4'];
+
+        $config = [
+            'db_driver' => 'orm',
+            'client_class' => 'dumb_class',
+            'access_token_class' => 'dumb_access_token_class',
+            'refresh_token_class' => 'dumb_refresh_token_class',
+            'auth_code_class' => 'dumb_auth_code_class',
+            'service' => [
+                'options' => [
+                    'supported_scopes' => $scopes,
+                    'enforce_redirect' => true,
+                ],
+            ],
+        ];
+        $instance = new FOSOAuthServerExtension();
+        $instance->load([$config], $this->container);
+
+        $this->assertSame(
+            $this->container->getParameter('fos_oauth_server.server.options'),
+            [
+                'supported_scopes' => 'scope1 scope2 scope3 scope4',
+                'enforce_redirect' => true,
+            ]
         );
     }
 }

--- a/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
+++ b/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
@@ -13,11 +13,24 @@ declare(strict_types=1);
 
 namespace FOS\OAuthServerBundle\Tests\DependencyInjection;
 
+use FOS\OAuthServerBundle\DependencyInjection\FOSOAuthServerExtension;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 
 class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
 {
+    private $container;
+
+    public function setUp()
+    {
+        $parameterBag = new ParameterBag();
+        $this->container = new ContainerBuilder($parameterBag);
+
+        parent::setUp();
+    }
+
     public function testLoadAuthorizeRouting()
     {
         $locator = new FileLocator();
@@ -38,5 +51,52 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $tokenRoute = $collection->get('fos_oauth_server_token');
         $this->assertSame('/oauth/v2/token', $tokenRoute->getPath());
         $this->assertSame(['GET', 'POST'], $tokenRoute->getMethods());
+    }
+
+    public function testWithoutService()
+    {
+        $config = [
+            'db_driver' => 'orm',
+            'client_class' => 'dumb_class',
+            'access_token_class' => 'dumb_access_token_class',
+            'refresh_token_class' => 'dumb_refresh_token_class',
+            'auth_code_class' => 'dumb_auth_code_class',
+        ];
+        $instance = new FOSOAuthServerExtension();
+        $instance->load([$config], $this->container);
+
+        $this->assertSame(
+            $this->container->getParameter('fos_oauth_server.server.options'),
+            []
+        );
+    }
+
+    public function testMultilineScopes()
+    {
+        $scopes = <<<'SCOPES'
+scope1
+scope2
+scope3 scope4
+SCOPES;
+
+        $config = [
+            'db_driver' => 'orm',
+            'client_class' => 'dumb_class',
+            'access_token_class' => 'dumb_access_token_class',
+            'refresh_token_class' => 'dumb_refresh_token_class',
+            'auth_code_class' => 'dumb_auth_code_class',
+            'service' => [
+                'options' => [
+                    'supported_scopes' => $scopes,
+                ],
+            ],
+        ];
+        $instance = new FOSOAuthServerExtension();
+        $instance->load([$config], $this->container);
+
+        $this->assertSame(
+            $this->container->getParameter('fos_oauth_server.server.options'),
+            ['supported_scopes' => 'scope1 scope2 scope3 scope4']
+        );
     }
 }

--- a/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
+++ b/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FOS\OAuthServerBundle\Tests\DependencyInjection;
 
 use FOS\OAuthServerBundle\DependencyInjection\FOSOAuthServerExtension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -126,5 +127,29 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
                 'enforce_redirect' => true,
             ]
         );
+    }
+
+    public function testArraySupportedScopesWithSpace()
+    {
+        $scopes = ['scope1 scope2', 'scope3', 'scope4'];
+
+        $config = [
+            'db_driver' => 'orm',
+            'client_class' => 'dumb_class',
+            'access_token_class' => 'dumb_access_token_class',
+            'refresh_token_class' => 'dumb_refresh_token_class',
+            'auth_code_class' => 'dumb_auth_code_class',
+            'service' => [
+                'options' => [
+                    'supported_scopes' => $scopes,
+                    'enforce_redirect' => true,
+                ],
+            ],
+        ];
+        $instance = new FOSOAuthServerExtension();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The array notation for supported_scopes should not contain spaces in array items. Either use full array notation or use the string notation for supported_scopes. See https://git.io/vx1X0 for more informations.');
+        $instance->load([$config], $this->container);
     }
 }


### PR DESCRIPTION
Currently, if you have an important number of scopes, you must set them into a one-line config option, which come to be really hard to read:

```yaml
fos_oauth_server:
      service:
          options:
              supported_scopes: scope1 scope2 scope3 scope4 scope5 scope6
```

This PR allow using an array:
```yaml
fos_oauth_server:
      service:
          options:
              supported_scopes:
                - scope1
                - scope2
                - scope3
                - scope4
                - scope5
                - scope6
```

It still works with a string if you have a small number of scopes
```yaml
fos_oauth_server:
      service:
          options:
              supported_scopes: scope1 scope2
```