### PR TITLE
Second argument of Response class need a interger

### DIFF
--- a/Security/EntryPoint/OAuthEntryPoint.php
+++ b/Security/EntryPoint/OAuthEntryPoint.php
@@ -16,6 +16,7 @@ namespace FOS\OAuthServerBundle\Security\EntryPoint;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2AuthenticateException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
@@ -31,7 +32,7 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
     public function start(Request $request, AuthenticationException $authException = null)
     {
         $exception = new OAuth2AuthenticateException(
-            OAuth2::HTTP_UNAUTHORIZED,
+            Response::HTTP_UNAUTHORIZED,
             OAuth2::TOKEN_TYPE_BEARER,
             $this->serverService->getVariable(OAuth2::CONFIG_WWW_REALM),
             'access_denied',


### PR DESCRIPTION
Since symfony 4, the constructor of the class Response has changed.
Now, need a integer for the second argument.