### PR TITLE
Mark a client as trusted

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -159,12 +159,13 @@ class AuthorizeController
         $form = $this->authorizeForm;
         $formHandler = $this->authorizeFormHandler;
 
+        $client = $this->getClient();
         $event = $this->eventDispatcher->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            new OAuthEvent($user, $client)
         );
 
-        if ($event->isAuthorizedClient()) {
+        if ($event->isAuthorizedClient() || $client->isTrusted()) {
             $scope = $request->get('scope', null);
 
             return $this->oAuth2Server->finishClientAuthorization(true, $user, $request, $scope);

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -41,6 +41,11 @@ class Client implements ClientInterface
      */
     protected $allowedGrantTypes = array();
 
+    /**
+     * @var bool
+     */
+    protected $trusted = false;
+
     public function __construct()
     {
         $this->allowedGrantTypes[] = OAuth2::GRANT_TYPE_AUTH_CODE;
@@ -132,5 +137,21 @@ class Client implements ClientInterface
     public function getAllowedGrantTypes()
     {
         return $this->allowedGrantTypes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTrusted($trusted)
+    {
+        $this->trusted = $trusted;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTrusted()
+    {
+        return $this->trusted;
     }
 }

--- a/Model/ClientInterface.php
+++ b/Model/ClientInterface.php
@@ -56,4 +56,14 @@ interface ClientInterface extends IOAuth2Client
      * @return array
      */
     public function getAllowedGrantTypes();
+
+    /**
+     * @param bool $trusted
+     */
+    public function setTrusted($trusted);
+
+    /**
+     * @return bool
+     */
+    public function isTrusted();
 }

--- a/Propel/Client.php
+++ b/Propel/Client.php
@@ -27,6 +27,7 @@ class Client extends BaseClient implements ClientInterface
         ));
         $this->setRandomId(Random::generateToken());
         $this->setSecret(Random::generateToken());
+        $this->setTrusted(false);
     }
 
     /**
@@ -43,5 +44,13 @@ class Client extends BaseClient implements ClientInterface
     public function getPublicId()
     {
         return sprintf('%s_%s', $this->getId(), $this->getRandomId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTrusted()
+    {
+        return $this->trusted;
     }
 }

--- a/Resources/config/doctrine/Client.couchdb.xml
+++ b/Resources/config/doctrine/Client.couchdb.xml
@@ -6,5 +6,6 @@
         <field name="redirectUris" fieldName="redirectUris" type="mixed" />
         <field name="secret" fieldName="secret" type="string" />
         <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="mixed" />
+        <field name="trusted" fieldName="trusted" type="mixed" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -9,5 +9,6 @@
         <field name="redirectUris" fieldName="redirectUris" type="collection" />
         <field name="secret" fieldName="secret" type="string" />
         <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="collection" />
+        <field name="trusted" fieldName="trusted" type="boolean" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Client.orm.xml
+++ b/Resources/config/doctrine/Client.orm.xml
@@ -9,5 +9,6 @@
         <field name="redirectUris" column="redirect_uris" type="array" />
         <field name="secret" column="secret" type="string" />
         <field name="allowedGrantTypes" column="allowed_grant_types" type="array" />
+        <field name="trusted" column="trusted" type="boolean" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -6,6 +6,7 @@
         <column name="redirect_uris" type="array" required="true" />
         <column name="secret" type="varchar" required="true" />
         <column name="allowed_grant_types" type="array" required="true" />
+        <column name="trusted" type="boolean" required="true" />
 
         <behavior name="typehintable">
             <parameter name="redirect_uris" value="array" />


### PR DESCRIPTION
I'm using OAuth2 for internal service authentication and the authorization form is not needed.

This PR skips the authorization screen if the client is marked as trusted.