### PR TITLE
Delegate user credential checking to PasswordChecker

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -121,6 +121,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                         ->children()
                             ->scalarNode('storage')->defaultValue('fos_oauth_server.storage.default')->cannotBeEmpty()->end()
+                            ->scalarNode('password_checker')->defaultValue('fos_oauth_server.password_checker.default')->cannotBeEmpty()->end()
                             ->scalarNode('user_provider')->defaultNull()->end()
                             ->scalarNode('client_manager')->defaultValue('fos_oauth_server.client_manager.default')->end()
                             ->scalarNode('access_token_manager')->defaultValue('fos_oauth_server.access_token_manager.default')->end()

--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -46,6 +46,7 @@ class FOSOAuthServerExtension extends Extension
         }
 
         $container->setAlias('fos_oauth_server.storage', $config['service']['storage']);
+        $container->setAlias('fos_oauth_server.password_checker', $config['service']['password_checker']);
         $container->setAlias('fos_oauth_server.client_manager', $config['service']['client_manager']);
         $container->setAlias('fos_oauth_server.access_token_manager', $config['service']['access_token_manager']);
         $container->setAlias('fos_oauth_server.refresh_token_manager', $config['service']['refresh_token_manager']);

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -14,7 +14,11 @@
             <argument type="service" id="fos_oauth_server.access_token_manager" />
             <argument type="service" id="fos_oauth_server.refresh_token_manager" />
             <argument type="service" id="fos_oauth_server.auth_code_manager" />
+            <argument type="service" id="fos_oauth_server.password_checker" />
             <argument type="service" id="fos_oauth_server.user_provider" on-invalid="null" />
+        </service>
+
+        <service id="fos_oauth_server.password_checker.default" class="FOS\OAuthServerBundle\Storage\PasswordChecker" public="false">
             <argument type="service" id="security.encoder_factory" />
         </service>
 

--- a/Storage/PasswordChecker.php
+++ b/Storage/PasswordChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Storage;
+
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class PasswordChecker implements PasswordCheckerInterface
+{
+    /**
+     * @var EncoderFactoryInterface
+     */
+    protected $encoderFactory;
+
+    /**
+     * @param EncoderFactoryInterface $encoderFactory
+     */
+    public function __construct(EncoderFactoryInterface $encoderFactory)
+    {
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validate(UserInterface $user, $password): bool
+    {
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        return $encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt());
+    }
+}

--- a/Storage/PasswordCheckerInterface.php
+++ b/Storage/PasswordCheckerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Storage;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface PasswordCheckerInterface
+{
+    /**
+     * Validate the user's password matches
+     *
+     * @param  UserInterface $user
+     * @param  string        $password
+     * @return bool
+     */
+    public function validate(UserInterface $user, $password): bool;
+}

--- a/Tests/Storage/PasswordCheckerTest.php
+++ b/Tests/Storage/PasswordCheckerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Tests\Storage;
+
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use FOS\OAuthServerBundle\Storage\PasswordChecker;
+
+class PasswordCheckerTest extends \PHPUnit\Framework\TestCase
+{
+    protected $encoderFactory;
+
+    protected $passwordChecker;
+
+    public function setUp()
+    {
+        $this->encoderFactory = $this->getMockBuilder(EncoderFactoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->passwordChecker = new PasswordChecker($this->encoderFactory);
+    }
+
+    public function testValidateReturnsTrueOnValidCredentials()
+    {
+        $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $user->expects($this->once())
+            ->method('getPassword')->with()->will($this->returnValue('foo'));
+        $user->expects($this->once())
+            ->method('getSalt')->with()->will($this->returnValue('bar'));
+
+        $encoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $encoder->expects($this->once())
+            ->method('isPasswordValid')
+            ->with('foo', 'baz', 'bar')
+            ->will($this->returnValue(true))
+        ;
+
+        $this->encoderFactory->expects($this->once())
+            ->method('getEncoder')
+            ->with($user)
+            ->will($this->returnValue($encoder))
+        ;
+
+        $this->assertTrue($this->passwordChecker->validate($user, 'baz'));
+    }
+
+    public function testValidateReturnsFalseOnInvalidCredentials()
+    {
+        $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $user->expects($this->once())
+            ->method('getPassword')->with()->will($this->returnValue('foo'));
+        $user->expects($this->once())
+            ->method('getSalt')->with()->will($this->returnValue('bar'));
+
+        $encoder = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $encoder->expects($this->once())
+            ->method('isPasswordValid')
+            ->with('foo', 'baz', 'bar')
+            ->will($this->returnValue(false))
+        ;
+
+        $this->encoderFactory->expects($this->once())
+            ->method('getEncoder')
+            ->with($user)
+            ->will($this->returnValue($encoder))
+        ;
+
+        $this->assertFalse($this->passwordChecker->validate($user, 'baz'));
+    }
+}


### PR DESCRIPTION
Storage component expects user/password to come from the database. I have a situation in which I would like to forward the credentials along to an external processor (LDAP, in my case). My first thought was to use a custom encoder with an LDAP service embedded, but that won't work because the encoder factory generates the encoder. Second approach is to extend the storage class or delegate to it. In either case, this leads to a lot of boilerplate (either messy constructor in the first case, or a lot of unnecessarily overridden methods to fulfill the interfaces in the latter), when I really only needed one line changed.

This approach allows the storage service to delegate the actual password checking, which defaults to using the encoder as before (no BC break). With this change, it's easy to override the password checker to implement whatever functionality is needed to check the password. I also made the password checker not nullable and swapped the order of the arguments to keep the nullable argument at the end. It didn't make sense to me that prior logic had the encoder factory as nullable, but called `getEncoder` on it directly without checking for null anyway.

This PR represents the simplest approach I could think of that provides extensibility without a BC break. Please let me know if there's a more Symfony-esque way of accomplishing this - I'm open to placing the functionality somewhere else, renaming files/methods, etc.