### PR TITLE
SF 4.1: Referencing controllers with a single colon is deprecated 

### DIFF
--- a/Resources/config/routing/authorize.xml
+++ b/Resources/config/routing/authorize.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="fos_oauth_server_authorize" path="/oauth/v2/auth" methods="GET POST">
-        <default key="_controller">fos_oauth_server.controller.authorize:authorizeAction</default>
+        <default key="_controller">fos_oauth_server.controller.authorize::authorizeAction</default>
     </route>
 
 </routes>

--- a/Resources/config/routing/token.xml
+++ b/Resources/config/routing/token.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="fos_oauth_server_token" path="/oauth/v2/token" methods="GET POST">
-        <default key="_controller">fos_oauth_server.controller.token:tokenAction</default>
+        <default key="_controller">fos_oauth_server.controller.token::tokenAction</default>
     </route>
 
 </routes>


### PR DESCRIPTION
Fixing deprecated notice for Symfony 4.1: 
`Referencing controllers with a single colon is deprecated since Symfony 4.1`