### PR TITLE
Add conflict section with newer versions of MongoDB ODM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
         "symfony/form" : "Needed to be able to use the AuthorizeFormType",
         "symfony/console": "Needed to be able to use commands"
     },
+    "conflict": {
+        "doctrine/mongodb-odm": ">=2"
+    },
     "autoload": {
         "psr-4": { "FOS\\OAuthServerBundle\\": "" },
         "exclude-from-classmap": ["/Tests/"]


### PR DESCRIPTION
This adds Doctrine MongoDB ODM 2.0 and newer to the conflicts section. Reason is that the XML mapping files are no longer compatible, which causes fatal errors. I'll prepare a separate PR for the master branch which will conflict with older versions of ODM and update the mapping files accordingly.