### PR TITLE
Fix deprecations from Symfony 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION=2.8.* COVERAGE=true
     - php: 7.2
+      env: SYMFONY_VERSION=4.2.* COVERAGE=true
+    - php: 7.2
       env: SYMFONY_VERSION=3.4.* COVERAGE=true
     - php: 7.2
       env: DEPENDENCIES=beta

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,8 +27,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fos_oauth_server');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('fos_oauth_server');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('fos_oauth_server');
+        }
 
         $supportedDrivers = array('orm', 'mongodb', 'propel', 'custom');
 


### PR DESCRIPTION
This fixes the tree builder deprecation that comes up starting with Symfony 4.2.

@dkarlovi unfortunately, the `RandomTest` is broken when using Symfony 3 or later; `runInSeparateProcess` produces a fatal error:
```
Fatal error: Uncaught Error: Using $this when not in object context in /private/var/folders/rn/1wpg9zfn4gbd84dl26xzbfzm0000gn/T/FOSOAuthServerBundle/ContainerHAkME25/getCacheWarmerService.php on line 16

Error: Using $this when not in object context in /private/var/folders/rn/1wpg9zfn4gbd84dl26xzbfzm0000gn/T/FOSOAuthServerBundle/ContainerHAkME25/getCacheWarmerService.php on line 16

Call Stack:
    0.0143     966088   1. {main}() Standard input code:0
    0.3101   27238072   2. require_once('/private/var/folders/rn/1wpg9zfn4gbd84dl26xzbfzm0000gn/T/FOSOAuthServerBundle/ContainerHAkME25/getCacheWarmerService.php') Standard input code:1219
```

Dropping `runInSeparateProcess` drops the fatal but causes an assertion failure in the test. How do you want me to proceed?