### PR TITLE
[2.0] Fix deprecations from Symfony 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION=4.0.*
     - php: 7.2
+      env: SYMFONY_VERSION=4.2.*
+    - php: 7.2
       env: SYMFONY_VERSION=4.0.* DEPENDENCIES=beta
 
 cache:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,10 +29,17 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('fos_oauth_server');
 
-        /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = $treeBuilder->root('fos_oauth_server');
+            /** @var ArrayNodeDefinition $rootNode */
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+
+            /** @var ArrayNodeDefinition $rootNode */
+            $rootNode = $treeBuilder->root('fos_oauth_server');
+        }
 
         $supportedDrivers = ['orm', 'mongodb', 'propel', 'custom'];
 


### PR DESCRIPTION
This ports #598 to master. Build is currently unstable due to phpstan errors.

@dkarlovi we should probably update the build order in the makefile to get test results before starting static inspection. The other alternative is to use [Build Stages](https://docs.travis-ci.com/user/build-stages/) on travis to run stuff more selectively.