### PR TITLE
FIX: adds support for using custom user checker

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -39,9 +39,11 @@ class OAuthFactory implements SecurityFactoryInterface
         }
 
         $providerId = 'security.authentication.provider.fos_oauth_server.'.$id;
+        $checkerId = 'security.user_checker.'.$id;
         $container
             ->setDefinition($providerId, new $definitionClass('fos_oauth_server.security.authentication.provider'))
             ->replaceArgument(0, new Reference($userProvider))
+            ->replaceArgument(2, new Reference($checkerId))
         ;
 
         $listenerId = 'security.authentication.listener.fos_oauth_server.'.$id;


### PR DESCRIPTION
Injects user checker service specified in firewall configuration to authentication provider injecting same way as it is done in standard symfony providers

Custom user checker service is always created by symfony security based on standard firewall.user_checker configuration option, all we need is to inject it to authentication [provider]

Solves #478 