### PR TITLE
Fix TreeBuilder deprecation warning from Symfony 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,10 +29,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('fos_oauth_server');
 
         /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = $treeBuilder->root('fos_oauth_server');
+        $rootNode = $treeBuilder->getRootNode();
 
         $supportedDrivers = ['orm', 'mongodb', 'propel', 'custom'];
 


### PR DESCRIPTION
Setting root node after construction throws a deprecation error after upgrading to Symfony 4.2+.

https://github.com/symfony/symfony/blob/4.2/UPGRADE-4.2.md#config

```
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
```