### PR TITLE
[Symfony v4.3] Templating is deprecated, use Twig instead 

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -19,7 +19,6 @@ use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,6 +30,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Twig\Environment;
 
 /**
  * Controller handling basic authorization.
@@ -65,9 +65,9 @@ class AuthorizeController
     private $oAuth2Server;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var RequestStack
@@ -90,11 +90,6 @@ class AuthorizeController
     private $clientManager;
 
     /**
-     * @var string
-     */
-    private $templateEngineType;
-
-    /**
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
@@ -109,37 +104,34 @@ class AuthorizeController
      * @param Form                     $authorizeForm
      * @param AuthorizeFormHandler     $authorizeFormHandler
      * @param OAuth2                   $oAuth2Server
-     * @param EngineInterface          $templating
+     * @param Environment              $twig
      * @param TokenStorageInterface    $tokenStorage
      * @param UrlGeneratorInterface    $router
      * @param ClientManagerInterface   $clientManager
      * @param EventDispatcherInterface $eventDispatcher
      * @param SessionInterface         $session
-     * @param string                   $templateEngineType
      */
     public function __construct(
         RequestStack $requestStack,
         Form $authorizeForm,
         AuthorizeFormHandler $authorizeFormHandler,
         OAuth2 $oAuth2Server,
-        EngineInterface $templating,
+        Environment $twig,
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $router,
         ClientManagerInterface $clientManager,
         EventDispatcherInterface $eventDispatcher,
-        SessionInterface $session = null,
-        $templateEngineType = 'twig'
+        SessionInterface $session = null
     ) {
         $this->requestStack = $requestStack;
         $this->session = $session;
         $this->authorizeForm = $authorizeForm;
         $this->authorizeFormHandler = $authorizeFormHandler;
         $this->oAuth2Server = $oAuth2Server;
-        $this->templating = $templating;
+        $this->twig = $twig;
         $this->tokenStorage = $tokenStorage;
         $this->router = $router;
         $this->clientManager = $clientManager;
-        $this->templateEngineType = $templateEngineType;
         $this->eventDispatcher = $eventDispatcher;
     }
 
@@ -183,7 +175,7 @@ class AuthorizeController
             'client' => $this->getClient(),
         ];
 
-        return $this->renderAuthorize($data, $this->templating, $this->templateEngineType);
+        return $this->renderAuthorize($data);
     }
 
     /**
@@ -261,16 +253,18 @@ class AuthorizeController
     /**
      * @throws \RuntimeException
      */
-    protected function renderAuthorize(array $data, EngineInterface $engine, string $engineType): Response
+    protected function renderAuthorize(array $data): Response
     {
-        return $engine->renderResponse(
-            '@FOSOAuthServer/Authorize/authorize.html.'.$engineType,
+        $response = $this->twig->render(
+            '@FOSOAuthServer/Authorize/authorize.html.twig',
             $data
         );
+
+        return $response instanceof Response ? $response : new Response($response);
     }
 
     /**
-     * @return null|Request
+     * @return Request|null
      */
     private function getCurrentRequest()
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,6 @@ class Configuration implements ConfigurationInterface
 
         $this->addAuthorizeSection($rootNode);
         $this->addServiceSection($rootNode);
-        $this->addTemplateSection($rootNode);
 
         return $treeBuilder;
     }
@@ -132,20 +131,6 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('variable')->end()
                             ->end()
                         ->end()
-                    ->end()
-                ->end()
-            ->end()
-        ;
-    }
-
-    private function addTemplateSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('template')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->scalarNode('engine')->defaultValue('twig')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Form/Handler/AuthorizeFormHandler.php
+++ b/Form/Handler/AuthorizeFormHandler.php
@@ -94,7 +94,7 @@ class AuthorizeFormHandler
         }
 
         $this->form->handleRequest($request);
-        if (!$this->form->isValid()) {
+        if ($this->form->isSubmitted() && $this->form->isValid() === false) {
             return false;
         }
 

--- a/Model/ClientManagerInterface.php
+++ b/Model/ClientManagerInterface.php
@@ -26,14 +26,14 @@ interface ClientManagerInterface
     public function getClass();
 
     /**
-     * @return null|ClientInterface
+     * @return ClientInterface|null
      */
     public function findClientBy(array $criteria);
 
     /**
      * @param mixed $publicId
      *
-     * @return null|ClientInterface
+     * @return ClientInterface|null
      */
     public function findClientByPublicId($publicId);
 

--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -28,13 +28,12 @@
             <argument type="service" id="fos_oauth_server.authorize.form" />
             <argument type="service" id="fos_oauth_server.authorize.form.handler" />
             <argument type="service" id="fos_oauth_server.server" />
-            <argument type="service" id="templating" />
+            <argument type="service" id="twig" />
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="router" />
             <argument type="service" id="fos_oauth_server.client_manager" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="session" on-invalid="null" />
-            <argument>%fos_oauth_server.template.engine%</argument>
         </service>
     </services>
 

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -50,8 +50,6 @@ fos_oauth_server:
 
             # Enforce state to be passed in authorization (see RFC 6749, section 10.12)
             #enforce_state: true or false
-    template:
-        engine:                 twig
 ```
 
 [Back to index](index.md)

--- a/Security/Authentication/Provider/OAuthProvider.php
+++ b/Security/Authentication/Provider/OAuthProvider.php
@@ -60,7 +60,7 @@ class OAuthProvider implements AuthenticationProviderInterface
     /**
      * @param OAuthToken&TokenInterface $token
      *
-     * @return null|OAuthToken
+     * @return OAuthToken|null
      */
     public function authenticate(TokenInterface $token)
     {

--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -74,8 +74,8 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
      * @param AccessTokenManagerInterface  $accessTokenManager
      * @param RefreshTokenManagerInterface $refreshTokenManager
      * @param AuthCodeManagerInterface     $authCodeManager
-     * @param null|UserProviderInterface   $userProvider
-     * @param null|EncoderFactoryInterface $encoderFactory
+     * @param UserProviderInterface|null   $userProvider
+     * @param EncoderFactoryInterface|null $encoderFactory
      */
     public function __construct(ClientManagerInterface $clientManager, AccessTokenManagerInterface $accessTokenManager,
         RefreshTokenManagerInterface $refreshTokenManager, AuthCodeManagerInterface $authCodeManager,

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -19,7 +19,6 @@ use FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler;
 use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use OAuth2\OAuth2;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
@@ -33,6 +32,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Twig\Environment;
 
 class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
 {
@@ -62,9 +62,9 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
     protected $oAuth2Server;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EngineInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|Environment
      */
-    protected $templateEngine;
+    protected $twig;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|TokenStorageInterface
@@ -85,11 +85,6 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcherInterface
      */
     protected $eventDispatcher;
-
-    /**
-     * @var string
-     */
-    protected $templateEngineType;
 
     /**
      * @var AuthorizeController
@@ -149,7 +144,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $this->templateEngine = $this->getMockBuilder(EngineInterface::class)
+        $this->twig = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -173,20 +168,18 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $this->templateEngineType = 'twig';
 
         $this->instance = new AuthorizeController(
             $this->requestStack,
             $this->form,
             $this->authorizeFormHandler,
             $this->oAuth2Server,
-            $this->templateEngine,
+            $this->twig,
             $this->tokenStorage,
             $this->router,
             $this->clientManager,
             $this->eventDispatcher,
-            $this->session,
-            $this->templateEngineType
+            $this->session
         );
 
         /** @var \PHPUnit_Framework_MockObject_MockObject&Request $request */
@@ -309,9 +302,9 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        $this->templateEngine
+        $this->twig
             ->expects($this->at(0))
-            ->method('renderResponse')
+            ->method('render')
             ->with(
                 '@FOSOAuthServer/Authorize/authorize.html.twig',
                 [
@@ -468,9 +461,9 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = new Response();
 
-        $this->templateEngine
+        $this->twig
             ->expects($this->at(0))
-            ->method('renderResponse')
+            ->method('render')
             ->with(
                 '@FOSOAuthServer/Authorize/authorize.html.twig',
                 [

--- a/Tests/Form/Handler/AuthorizeFormHandlerTest.php
+++ b/Tests/Form/Handler/AuthorizeFormHandlerTest.php
@@ -356,6 +356,13 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->form
             ->expects($this->once())
+            ->method('isSubmitted')
+            ->with()
+            ->willReturn(true)
+        ;
+
+        $this->form
+            ->expects($this->once())
             ->method('isValid')
             ->with()
             ->willReturn(false)
@@ -411,6 +418,13 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
             ->method('handleRequest')
             ->with($this->request)
             ->willReturn($this->form)
+        ;
+
+        $this->form
+            ->expects($this->once())
+            ->method('isSubmitted')
+            ->with()
+            ->willReturn(true)
         ;
 
         $this->form

--- a/Tests/Functional/TestCase.php
+++ b/Tests/Functional/TestCase.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 abstract class TestCase extends WebTestCase
 {
     /**
-     * @var null|KernelInterface
+     * @var KernelInterface|null
      */
     protected static $kernel;
 

--- a/Tests/Functional/config/config.yml
+++ b/Tests/Functional/config/config.yml
@@ -1,6 +1,4 @@
 framework:
-    templating:
-        engines: ["twig"]
     form: ~
     secret: test
     router:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/dependency-injection": "~3.0|~4.0",
         "symfony/framework-bundle": "~3.0|~4.0",
-        "symfony/security-bundle": "~3.0|~4.0"
+        "symfony/security-bundle": "~3.0|~4.0",
+        "symfony/twig-bundle": "~3.0|^4.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.0",
@@ -37,7 +38,6 @@
         "symfony/form": "~3.0|~4.0",
         "symfony/phpunit-bridge": "~3.0|~4.0",
         "symfony/templating": "~3.0|~4.0",
-        "symfony/twig-bundle": "~3.0|^4.0",
         "symfony/yaml": "~3.0|~4.0",
         "willdurand/propel-typehintable-behavior": "~1.0"
     },


### PR DESCRIPTION
Hello,
Templating component is [deprecated](https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration) in Symfony 4.3. This PR makes this bundle to use Twig directly.

Which is correct branch for this PR, master or v1.6? 
What's happening to PHPStan in master? It finds 139 errors, although they were fixed up to lvl 6 last year https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/573