### PR TITLE
Make tests compatible with PHPUnit 8

### DIFF
--- a/Tests/Command/CleanCommandTest.php
+++ b/Tests/Command/CleanCommandTest.php
@@ -27,17 +27,17 @@ class CleanCommandTest extends \PHPUnit\Framework\TestCase
     private $command;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|TokenManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|TokenManagerInterface
      */
     private $accessTokenManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|TokenManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|TokenManagerInterface
      */
     private $refreshTokenManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|AuthCodeManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|AuthCodeManagerInterface
      */
     private $authCodeManager;
 
@@ -64,7 +64,7 @@ class CleanCommandTest extends \PHPUnit\Framework\TestCase
     /**
      * Delete expired tokens for provided classes.
      */
-    public function testItShouldRemoveExpiredToken()
+    public function testItShouldRemoveExpiredToken(): void
     {
         $expiredAccessTokens = 5;
         $this->accessTokenManager
@@ -100,7 +100,7 @@ class CleanCommandTest extends \PHPUnit\Framework\TestCase
     /**
      * Skip classes for deleting expired tokens that do not implement AuthCodeManagerInterface or TokenManagerInterface.
      */
-    public function testItShouldNotRemoveExpiredTokensForOtherClasses()
+    public function testItShouldNotRemoveExpiredTokensForOtherClasses(): void
     {
         $this->markTestIncomplete('Needs a better way of testing this');
 

--- a/Tests/Command/CreateClientCommandTest.php
+++ b/Tests/Command/CreateClientCommandTest.php
@@ -27,7 +27,7 @@ class CreateClientCommandTest extends TestCase
     private $command;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ClientManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|ClientManagerInterface
      */
     private $clientManager;
 
@@ -53,7 +53,7 @@ class CreateClientCommandTest extends TestCase
      *
      * @param string $client a fully qualified class name
      */
-    public function testItShouldCreateClient($client)
+    public function testItShouldCreateClient($client): void
     {
         $this
             ->clientManager

--- a/Tests/Controller/AuthorizeControllerTest.php
+++ b/Tests/Controller/AuthorizeControllerTest.php
@@ -38,52 +38,52 @@ use Twig\Environment as TwigEnvironment;
 class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|RequestStack
+     * @var \PHPUnit\Framework\MockObject\MockObject|RequestStack
      */
     protected $requestStack;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|SessionInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|SessionInterface
      */
     protected $session;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Form
+     * @var \PHPUnit\Framework\MockObject\MockObject|Form
      */
     protected $form;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|AuthorizeFormHandler
+     * @var \PHPUnit\Framework\MockObject\MockObject|AuthorizeFormHandler
      */
     protected $authorizeFormHandler;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|OAuth2
+     * @var \PHPUnit\Framework\MockObject\MockObject|OAuth2
      */
     protected $oAuth2Server;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|TokenStorageInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|TokenStorageInterface
      */
     protected $tokenStorage;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|TwigEnvironment
+     * @var \PHPUnit\Framework\MockObject\MockObject|TwigEnvironment
      */
     protected $twig;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|UrlGeneratorInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|UrlGeneratorInterface
      */
     protected $router;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ClientManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|ClientManagerInterface
      */
     protected $clientManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcherInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|EventDispatcherInterface
      */
     protected $eventDispatcher;
 
@@ -93,46 +93,46 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
     protected $instance;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Request
+     * @var \PHPUnit\Framework\MockObject\MockObject|Request
      */
     protected $request;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ParameterBag
+     * @var \PHPUnit\Framework\MockObject\MockObject|ParameterBag
      */
     protected $requestQuery;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ParameterBag
+     * @var \PHPUnit\Framework\MockObject\MockObject|ParameterBag
      */
     protected $requestRequest;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|UserInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|UserInterface
      */
     protected $user;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ClientInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|ClientInterface
      */
     protected $client;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|PreAuthorizationEvent
+     * @var \PHPUnit\Framework\MockObject\MockObject|PreAuthorizationEvent
      */
     protected $preAuthorizationEvent;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|PostAuthorizationEvent
+     * @var \PHPUnit\Framework\MockObject\MockObject|PostAuthorizationEvent
      */
     protected $postAuthorizationEvent;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|FormView
+     * @var \PHPUnit\Framework\MockObject\MockObject|FormView
      */
     protected $formView;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->requestStack = $this->getMockBuilder(RequestStack::class)
             ->disableOriginalConstructor()
@@ -188,7 +188,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
             $this->session
         );
 
-        /** @var \PHPUnit_Framework_MockObject_MockObject&Request $request */
+        /** @var \PHPUnit\Framework\MockObject\MockObject&Request $request */
         $request = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock()
@@ -228,7 +228,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testAuthorizeActionWillThrowAccessDeniedException()
+    public function testAuthorizeActionWillThrowAccessDeniedException(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -253,7 +253,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
         $this->instance->authorizeAction($this->request);
     }
 
-    public function testAuthorizeActionWillRenderTemplate()
+    public function testAuthorizeActionWillRenderTemplate(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -325,7 +325,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($responseBody, $this->instance->authorizeAction($this->request)->getContent());
     }
 
-    public function testAuthorizeActionWillFinishClientAuthorization()
+    public function testAuthorizeActionWillFinishClientAuthorization(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -394,7 +394,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($response, $this->instance->authorizeAction($this->request));
     }
 
-    public function testAuthorizeActionWillEnsureLogout()
+    public function testAuthorizeActionWillEnsureLogout(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -480,7 +480,7 @@ class AuthorizeControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($responseBody, $this->instance->authorizeAction($this->request)->getContent());
     }
 
-    public function testAuthorizeActionWillProcessAuthorizationForm()
+    public function testAuthorizeActionWillProcessAuthorizationForm(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()

--- a/Tests/DependencyInjection/Compiler/GrantExtensionsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/GrantExtensionsCompilerPassTest.php
@@ -33,14 +33,14 @@ class GrantExtensionsCompilerPassTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->instance = new GrantExtensionsCompilerPass();
 
         parent::setUp();
     }
 
-    public function testProcessWillNotDoAnythingIfTheStorageDoesNotImplementOurInterface()
+    public function testProcessWillNotDoAnythingIfTheStorageDoesNotImplementOurInterface(): void
     {
         $container = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()
@@ -93,7 +93,7 @@ class GrantExtensionsCompilerPassTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->process($container));
     }
 
-    public function testProcessWillFailIfUriIsEmpty()
+    public function testProcessWillFailIfUriIsEmpty(): void
     {
         $container = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()
@@ -197,7 +197,7 @@ class GrantExtensionsCompilerPassTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->process($container));
     }
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $container = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()

--- a/Tests/DependencyInjection/Compiler/RequestStackCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RequestStackCompilerPassTest.php
@@ -31,11 +31,11 @@ class RequestStackCompilerPassTest extends \PHPUnit\Framework\TestCase
     protected $instance;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerBuilder
+     * @var \PHPUnit\Framework\MockObject\MockObject|ContainerBuilder
      */
     protected $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()
@@ -51,7 +51,7 @@ class RequestStackCompilerPassTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testProcessWithoutRequestStackDoesNothing()
+    public function testProcessWithoutRequestStackDoesNothing(): void
     {
         $this->container
             ->expects($this->once())
@@ -63,7 +63,7 @@ class RequestStackCompilerPassTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->process($this->container));
     }
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $this->container
             ->expects($this->once())

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,14 +20,14 @@ use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
-    public function testShouldImplementConfigurationInterface()
+    public function testShouldImplementConfigurationInterface(): void
     {
         $rc = new \ReflectionClass(Configuration::class);
 
         $this->assertTrue($rc->implementsInterface(ConfigurationInterface::class));
     }
 
-    public function testCouldBeConstructedWithoutAnyArguments()
+    public function testCouldBeConstructedWithoutAnyArguments(): void
     {
         try {
             new Configuration();
@@ -39,7 +39,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testShouldNotMandatoryServiceIfNotCustomDriverIsUsed()
+    public function testShouldNotMandatoryServiceIfNotCustomDriverIsUsed(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -69,7 +69,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         ], $config);
     }
 
-    public function testShouldMakeClientManagerServiceMandatoryIfCustomDriverIsUsed()
+    public function testShouldMakeClientManagerServiceMandatoryIfCustomDriverIsUsed(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -86,7 +86,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         ]]);
     }
 
-    public function testShouldMakeAccessTokenManagerServiceMandatoryIfCustomDriverIsUsed()
+    public function testShouldMakeAccessTokenManagerServiceMandatoryIfCustomDriverIsUsed(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -106,7 +106,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         ]]);
     }
 
-    public function testShouldMakeRefreshTokenManagerServiceMandatoryIfCustomDriverIsUsed()
+    public function testShouldMakeRefreshTokenManagerServiceMandatoryIfCustomDriverIsUsed(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -127,7 +127,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         ]]);
     }
 
-    public function testShouldMakeAuthCodeManagerServiceMandatoryIfCustomDriverIsUsed()
+    public function testShouldMakeAuthCodeManagerServiceMandatoryIfCustomDriverIsUsed(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();
@@ -149,7 +149,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         ]]);
     }
 
-    public function testShouldLoadCustomDriverConfig()
+    public function testShouldLoadCustomDriverConfig(): void
     {
         $configuration = new Configuration();
         $processor = new Processor();

--- a/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
+++ b/Tests/DependencyInjection/FOSOAuthServerExtensionTest.php
@@ -25,7 +25,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
 {
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $parameterBag = new ParameterBag();
         $this->container = new ContainerBuilder($parameterBag);
@@ -33,14 +33,14 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testShouldImplementConfigurationInterface()
+    public function testShouldImplementConfigurationInterface(): void
     {
         $rc = new \ReflectionClass(FOSOAuthServerExtension::class);
 
         $this->assertTrue($rc->isSubclassOf(Extension::class));
     }
 
-    public function testCouldBeConstructedWithoutAnyArguments()
+    public function testCouldBeConstructedWithoutAnyArguments(): void
     {
         try {
             new FOSOAuthServerExtension();
@@ -52,7 +52,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testShouldLoadAuthorizeRelatedServicesIfAuthorizationIsEnabled()
+    public function testShouldLoadAuthorizeRelatedServicesIfAuthorizationIsEnabled(): void
     {
         $container = new ContainerBuilder();
 
@@ -72,7 +72,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($container->hasDefinition('fos_oauth_server.controller.authorize'));
     }
 
-    public function testShouldNotLoadAuthorizeRelatedServicesIfAuthorizationIsDisabled()
+    public function testShouldNotLoadAuthorizeRelatedServicesIfAuthorizationIsDisabled(): void
     {
         $container = new ContainerBuilder();
 
@@ -92,7 +92,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($container->hasDefinition('fos_oauth_server.controller.authorize'));
     }
 
-    public function testLoadAuthorizeRouting()
+    public function testLoadAuthorizeRouting(): void
     {
         $locator = new FileLocator();
         $loader = new XmlFileLoader($locator);
@@ -103,7 +103,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['GET', 'POST'], $authorizeRoute->getMethods());
     }
 
-    public function testLoadTokenRouting()
+    public function testLoadTokenRouting(): void
     {
         $locator = new FileLocator();
         $loader = new XmlFileLoader($locator);
@@ -114,7 +114,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['GET', 'POST'], $tokenRoute->getMethods());
     }
 
-    public function testWithoutService()
+    public function testWithoutService(): void
     {
         $config = [
             'db_driver' => 'orm',
@@ -132,7 +132,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testStringSupportedScopes()
+    public function testStringSupportedScopes(): void
     {
         $scopes = 'scope1 scope2 scope3 scope4';
 
@@ -160,7 +160,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testArraySupportedScopes()
+    public function testArraySupportedScopes(): void
     {
         $scopes = ['scope1', 'scope2', 'scope3', 'scope4'];
 
@@ -189,7 +189,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testArraySupportedScopesWithSpace()
+    public function testArraySupportedScopesWithSpace(): void
     {
         $scopes = ['scope1 scope2', 'scope3', 'scope4'];
 
@@ -213,7 +213,7 @@ class FOSOAuthServerExtensionTest extends \PHPUnit\Framework\TestCase
         $instance->load([$config], $this->container);
     }
 
-    public function testShouldAliasServivesWhenCustomDriverIsUsed()
+    public function testShouldAliasServivesWhenCustomDriverIsUsed(): void
     {
         $container = new ContainerBuilder();
         $extension = new FOSOAuthServerExtension();

--- a/Tests/DependencyInjection/Security/Factory/OAuthFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/OAuthFactoryTest.php
@@ -32,24 +32,24 @@ class OAuthFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->instance = new OAuthFactory();
 
         parent::setUp();
     }
 
-    public function testGetPosition()
+    public function testGetPosition(): void
     {
         $this->assertSame('pre_auth', $this->instance->getPosition());
     }
 
-    public function testGetKey()
+    public function testGetKey(): void
     {
         $this->assertSame('fos_oauth', $this->instance->getKey());
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $container = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()
@@ -113,7 +113,7 @@ class OAuthFactoryTest extends \PHPUnit\Framework\TestCase
         ], $this->instance->create($container, $id, $config, $userProvider, $defaultEntryPoint));
     }
 
-    public function testAddConfigurationDoesNothing()
+    public function testAddConfigurationDoesNothing(): void
     {
         $nodeDefinition = $this->getMockBuilder(NodeDefinition::class)
             ->disableOriginalConstructor()

--- a/Tests/Document/AuthCodeManagerTest.php
+++ b/Tests/Document/AuthCodeManagerTest.php
@@ -30,12 +30,12 @@ use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentManager
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentManager
      */
     protected $documentManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentRepository
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentRepository
      */
     protected $repository;
 
@@ -49,7 +49,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Doctrine\ODM\MongoDB\DocumentManager')) {
             $this->markTestSkipped('Doctrine MongoDB ODM has to be installed for this test to run.');
@@ -77,18 +77,18 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstructWillSetParameters()
+    public function testConstructWillSetParameters(): void
     {
         $this->assertAttributeSame($this->documentManager, 'dm', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
-    public function testGetClassWillReturnClassName()
+    public function testGetClassWillReturnClassName(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testFindAuthCodeBy()
+    public function testFindAuthCodeBy(): void
     {
         $randomResult = \random_bytes(10);
         $criteria = [
@@ -105,7 +105,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findAuthCodeBy($criteria));
     }
 
-    public function testUpdateAuthCode()
+    public function testUpdateAuthCode(): void
     {
         $authCode = $this->getMockBuilder(AuthCodeInterface::class)
             ->disableOriginalConstructor()
@@ -129,7 +129,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateAuthCode($authCode));
     }
 
-    public function testDeleteAuthCode()
+    public function testDeleteAuthCode(): void
     {
         $authCode = $this->getMockBuilder(AuthCodeInterface::class)
             ->disableOriginalConstructor()
@@ -153,7 +153,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->deleteAuthCode($authCode));
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $queryBuilder = $this->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()

--- a/Tests/Document/ClientManagerTest.php
+++ b/Tests/Document/ClientManagerTest.php
@@ -26,7 +26,7 @@ use FOS\OAuthServerBundle\Model\ClientInterface;
 class ClientManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentManager
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentManager
      */
     protected $documentManager;
 
@@ -36,7 +36,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
     protected $className;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentRepository
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentRepository
      */
     protected $repository;
 
@@ -45,7 +45,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Doctrine\ODM\MongoDB\DocumentManager')) {
             $this->markTestSkipped('Doctrine MongoDB ODM has to be installed for this test to run.');
@@ -73,19 +73,19 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstructWillSetParameters()
+    public function testConstructWillSetParameters(): void
     {
         $this->assertAttributeSame($this->documentManager, 'dm', $this->instance);
         $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
-    public function testGetClass()
+    public function testGetClass(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testFindClientBy()
+    public function testFindClientBy(): void
     {
         $randomResult = \random_bytes(5);
         $criteria = [
@@ -102,7 +102,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findClientBy($criteria));
     }
 
-    public function testUpdateClient()
+    public function testUpdateClient(): void
     {
         $client = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()
@@ -126,7 +126,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateClient($client));
     }
 
-    public function testDeleteClient()
+    public function testDeleteClient(): void
     {
         $client = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()

--- a/Tests/Document/TokenManagerTest.php
+++ b/Tests/Document/TokenManagerTest.php
@@ -35,12 +35,12 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
     protected $className;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentManager
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentManager
      */
     protected $documentManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|DocumentRepository
+     * @var \PHPUnit\Framework\MockObject\MockObject|DocumentRepository
      */
     protected $repository;
 
@@ -49,7 +49,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Doctrine\ODM\MongoDB\DocumentManager')) {
             $this->markTestSkipped('Doctrine MongoDB ODM has to be installed for this test to run.');
@@ -75,7 +75,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->instance = new TokenManager($this->documentManager, $this->className);
     }
 
-    public function testFindTokenByToken()
+    public function testFindTokenByToken(): void
     {
         $randomToken = \random_bytes(5);
         $randomResult = \random_bytes(5);
@@ -92,7 +92,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findTokenByToken($randomToken));
     }
 
-    public function testUpdateTokenPersistsAndFlushes()
+    public function testUpdateTokenPersistsAndFlushes(): void
     {
         $token = $this->getMockBuilder(AccessToken::class)
             ->disableOriginalConstructor()
@@ -114,12 +114,12 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateToken($token));
     }
 
-    public function testGetClass()
+    public function testGetClass(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testDeleteToken()
+    public function testDeleteToken(): void
     {
         $token = $this->getMockBuilder(AccessToken::class)
             ->disableOriginalConstructor()
@@ -143,7 +143,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->deleteToken($token));
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $queryBuilder = $this->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()

--- a/Tests/Entity/AuthCodeManagerTest.php
+++ b/Tests/Entity/AuthCodeManagerTest.php
@@ -31,7 +31,7 @@ use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|EntityManagerInterface
      */
     protected $entityManager;
 
@@ -45,7 +45,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->entityManager = $this->getMockBuilder(EntityManagerInterface::class)
             ->disableOriginalConstructor()
@@ -58,18 +58,18 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstructWillSetParameters()
+    public function testConstructWillSetParameters(): void
     {
         $this->assertAttributeSame($this->entityManager, 'em', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
-    public function testGetClassWillReturnClassName()
+    public function testGetClassWillReturnClassName(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testFindAuthCodeBy()
+    public function testFindAuthCodeBy(): void
     {
         $repository = $this->getMockBuilder(ObjectRepository::class)
             ->disableOriginalConstructor()
@@ -98,7 +98,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findAuthCodeBy($criteria));
     }
 
-    public function testUpdateAuthCode()
+    public function testUpdateAuthCode(): void
     {
         $authCode = $this->getMockBuilder(AuthCodeInterface::class)
             ->disableOriginalConstructor()
@@ -122,7 +122,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateAuthCode($authCode));
     }
 
-    public function testDeleteAuthCode()
+    public function testDeleteAuthCode(): void
     {
         $authCode = $this->getMockBuilder(AuthCodeInterface::class)
             ->disableOriginalConstructor()
@@ -146,7 +146,7 @@ class AuthCodeManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->deleteAuthCode($authCode));
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $randomResult = \random_bytes(10);
 

--- a/Tests/Entity/ClientManagerTest.php
+++ b/Tests/Entity/ClientManagerTest.php
@@ -26,7 +26,7 @@ use FOS\OAuthServerBundle\Model\ClientInterface;
 class ClientManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|EntityManagerInterface
      */
     protected $entityManager;
 
@@ -36,7 +36,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
     protected $className;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EntityRepository
+     * @var \PHPUnit\Framework\MockObject\MockObject|EntityRepository
      */
     protected $repository;
 
@@ -45,7 +45,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->entityManager = $this->getMockBuilder(EntityManagerInterface::class)
             ->disableOriginalConstructor()
@@ -69,19 +69,19 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstructWillSetParameters()
+    public function testConstructWillSetParameters(): void
     {
         $this->assertAttributeSame($this->entityManager, 'em', $this->instance);
         $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
-    public function testGetClass()
+    public function testGetClass(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testFindClientBy()
+    public function testFindClientBy(): void
     {
         $criteria = [
             \random_bytes(5),
@@ -98,7 +98,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findClientBy($criteria));
     }
 
-    public function testUpdateClient()
+    public function testUpdateClient(): void
     {
         $client = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()
@@ -122,7 +122,7 @@ class ClientManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateClient($client));
     }
 
-    public function testDeleteClient()
+    public function testDeleteClient(): void
     {
         $client = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()

--- a/Tests/Entity/TokenManagerTest.php
+++ b/Tests/Entity/TokenManagerTest.php
@@ -32,12 +32,12 @@ use FOS\OAuthServerBundle\Model\TokenInterface;
 class TokenManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|EntityManagerInterface
      */
     protected $entityManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|EntityRepository
+     * @var \PHPUnit\Framework\MockObject\MockObject|EntityRepository
      */
     protected $repository;
 
@@ -51,7 +51,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->className = AccessToken::class;
         $this->repository = $this->getMockBuilder(EntityRepository::class)
@@ -73,14 +73,14 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->instance = new TokenManager($this->entityManager, $this->className);
     }
 
-    public function testConstructWillSetParameters()
+    public function testConstructWillSetParameters(): void
     {
         $this->assertAttributeSame($this->entityManager, 'em', $this->instance);
         $this->assertAttributeSame($this->repository, 'repository', $this->instance);
         $this->assertAttributeSame($this->className, 'class', $this->instance);
     }
 
-    public function testUpdateTokenPersistsAndFlushes()
+    public function testUpdateTokenPersistsAndFlushes(): void
     {
         $token = new AccessToken();
 
@@ -99,12 +99,12 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateToken($token));
     }
 
-    public function testGetClass()
+    public function testGetClass(): void
     {
         $this->assertSame($this->className, $this->instance->getClass());
     }
 
-    public function testFindTokenBy()
+    public function testFindTokenBy(): void
     {
         $randomResult = \random_bytes(5);
 
@@ -122,7 +122,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($randomResult, $this->instance->findTokenBy($criteria));
     }
 
-    public function testUpdateToken()
+    public function testUpdateToken(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -146,7 +146,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->updateToken($token));
     }
 
-    public function testDeleteToken()
+    public function testDeleteToken(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -170,7 +170,7 @@ class TokenManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->instance->deleteToken($token));
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $randomResult = \random_bytes(10);
 

--- a/Tests/FOSOAuthServerBundleTest.php
+++ b/Tests/FOSOAuthServerBundleTest.php
@@ -26,11 +26,11 @@ class FOSOAuthServerBundleTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstruction()
+    public function testConstruction(): void
     {
         $bundle = new FOSOAuthServerBundle();
 
-        /** @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject $containerBuilder */
+        /** @var ContainerBuilder|\PHPUnit\Framework\MockObject\MockObject $containerBuilder */
         $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
             ->disableOriginalConstructor()
             ->setMethods([
@@ -40,7 +40,7 @@ class FOSOAuthServerBundleTest extends \PHPUnit\Framework\TestCase
             ->getMock()
         ;
 
-        /** @var SecurityExtension|\PHPUnit_Framework_MockObject_MockObject $securityExtension */
+        /** @var SecurityExtension|\PHPUnit\Framework\MockObject\MockObject $securityExtension */
         $securityExtension = $this->getMockBuilder(SecurityExtension::class)
             ->disableOriginalConstructor()
             ->getMock()

--- a/Tests/Form/Handler/AuthorizeFormHandlerTest.php
+++ b/Tests/Form/Handler/AuthorizeFormHandlerTest.php
@@ -44,7 +44,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->form = $this->getMockBuilder(FormInterface::class)
             ->disableOriginalConstructor()
@@ -78,7 +78,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    public function testConstructWillAcceptRequestObjectAsRequest()
+    public function testConstructWillAcceptRequestObjectAsRequest(): void
     {
         $request = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
@@ -91,7 +91,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertAttributeSame($request, 'requestStack', $this->instance);
     }
 
-    public function testConstructWillAcceptRequestStackObjectAsRequest()
+    public function testConstructWillAcceptRequestStackObjectAsRequest(): void
     {
         $requestStack = $this->getMockBuilder(RequestStack::class)
             ->disableOriginalConstructor()
@@ -104,7 +104,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertAttributeSame($requestStack, 'requestStack', $this->instance);
     }
 
-    public function testConstructWillAcceptNullAsRequest()
+    public function testConstructWillAcceptNullAsRequest(): void
     {
         $this->instance = new AuthorizeFormHandler($this->form, null);
         $this->assertAttributeSame($this->form, 'form', $this->instance);
@@ -115,7 +115,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertAttributeSame(null, 'requestStack', $this->instance);
     }
 
-    public function testConstructWillThrowException()
+    public function testConstructWillThrowException(): void
     {
         $exceptionMessage = sprintf(
             'Argument 2 of %s must be an instanceof RequestStack or Request',
@@ -128,7 +128,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         new AuthorizeFormHandler($this->form, new \stdClass());
     }
 
-    public function testIsAcceptedWillProxyValueToFormData()
+    public function testIsAcceptedWillProxyValueToFormData(): void
     {
         $data = new \stdClass();
         $data->accepted = \random_bytes(10);
@@ -143,7 +143,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($data->accepted, $this->instance->isAccepted());
     }
 
-    public function testIsRejectedWillNegateAcceptedValueFromFormData()
+    public function testIsRejectedWillNegateAcceptedValueFromFormData(): void
     {
         $dataWithAcceptedValueFalse = new \stdClass();
         $dataWithAcceptedValueFalse->accepted = false;
@@ -164,7 +164,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->instance->isRejected());
     }
 
-    public function testGetScopeWillProxyValueToFormData()
+    public function testGetScopeWillProxyValueToFormData(): void
     {
         $data = new \stdClass();
         $data->scope = \random_bytes(10);
@@ -179,13 +179,13 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($data->scope, $this->instance->getScope());
     }
 
-    public function testGetCurrentRequestWillReturnRequestObject()
+    public function testGetCurrentRequestWillReturnRequestObject(): void
     {
         $method = $this->getReflectionMethod('getCurrentRequest');
         $this->assertSame($this->request, $method->invoke($this->instance));
     }
 
-    public function testGetCurrentRequestWillReturnCurrentRequestFromRequestStack()
+    public function testGetCurrentRequestWillReturnCurrentRequestFromRequestStack(): void
     {
         $requestStack = $this->getMockBuilder(RequestStack::class)
             ->disableOriginalConstructor()
@@ -206,7 +206,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($request, $method->invoke($this->instance));
     }
 
-    public function testGetCurrentRequestWillReturnRequestServiceFromContainerIfNoneIsSet()
+    public function testGetCurrentRequestWillReturnRequestServiceFromContainerIfNoneIsSet(): void
     {
         $this->instance = new AuthorizeFormHandler($this->form, null);
         $this->instance->setContainer($this->container);
@@ -227,7 +227,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * @TODO Fix this behavior. This method MUST not modify $_GET.
      */
-    public function testOnSuccessWillReplaceGETSuperGlobal()
+    public function testOnSuccessWillReplaceGETSuperGlobal(): void
     {
         $method = $this->getReflectionMethod('onSuccess');
 
@@ -260,7 +260,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedSuperGlobalValue, $_GET);
     }
 
-    public function testProcessWillReturnFalseIfRequestIsNull()
+    public function testProcessWillReturnFalseIfRequestIsNull(): void
     {
         $this->instance = new AuthorizeFormHandler($this->form, null);
         $this->instance->setContainer($this->container);
@@ -275,7 +275,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->instance->process());
     }
 
-    public function testProcessWillSetFormData()
+    public function testProcessWillSetFormData(): void
     {
         $this->requestRequest
             ->expects($this->once())
@@ -309,7 +309,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->instance->process());
     }
 
-    public function testProcessWillHandleRequestOnPost()
+    public function testProcessWillHandleRequestOnPost(): void
     {
         $this->requestRequest
             ->expects($this->once())
@@ -371,7 +371,7 @@ class AuthorizeFormHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->instance->process());
     }
 
-    public function testProcessWillHandleRequestOnPostAndWillProcessDataIfFormIsValid()
+    public function testProcessWillHandleRequestOnPostAndWillProcessDataIfFormIsValid(): void
     {
         $this->requestRequest
             ->expects($this->once())

--- a/Tests/Form/Type/AuthorizeFormTypeTest.php
+++ b/Tests/Form/Type/AuthorizeFormTypeTest.php
@@ -41,7 +41,7 @@ class AuthorizeFormTypeTest extends TypeTestCase
         $this->instance = new AuthorizeFormType();
     }
 
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $accepted = true;
         $formData = [
@@ -70,9 +70,9 @@ class AuthorizeFormTypeTest extends TypeTestCase
         }
     }
 
-    public function testConfigureOptionsWillSetDefaultsOnTheOptionsResolver()
+    public function testConfigureOptionsWillSetDefaultsOnTheOptionsResolver(): void
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|OptionsResolver $resolver */
+        /** @var \PHPUnit\Framework\MockObject\MockObject|OptionsResolver $resolver */
         $resolver = $this->getMockBuilder(OptionsResolver::class)
             ->disableOriginalConstructor()
             ->getMock()
@@ -90,12 +90,12 @@ class AuthorizeFormTypeTest extends TypeTestCase
         $this->assertNull($this->instance->configureOptions($resolver));
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $this->assertSame('fos_oauth_server_authorize', $this->instance->getName());
     }
 
-    public function testGetBlockPrefix()
+    public function testGetBlockPrefix(): void
     {
         $this->assertSame('fos_oauth_server_authorize', $this->instance->getBlockPrefix());
     }

--- a/Tests/Functional/BootTest.php
+++ b/Tests/Functional/BootTest.php
@@ -20,7 +20,7 @@ class BootTest extends TestCase
      *
      * @param string $env
      */
-    public function testBoot($env)
+    public function testBoot($env): void
     {
         try {
             $kernel = static::createKernel(['env' => $env]);

--- a/Tests/Model/TokenTest.php
+++ b/Tests/Model/TokenTest.php
@@ -30,7 +30,7 @@ class TokenTest extends TestCase
      * @param mixed $expiresAt
      * @param mixed $expect
      */
-    public function testHasExpired($expiresAt, $expect)
+    public function testHasExpired($expiresAt, $expect): void
     {
         $token = new Token();
         $token->setExpiresAt($expiresAt);
@@ -47,14 +47,14 @@ class TokenTest extends TestCase
         ];
     }
 
-    public function testExpiresIn()
+    public function testExpiresIn(): void
     {
         $token = new Token();
 
         $this->assertSame(PHP_INT_MAX, $token->getExpiresIn());
     }
 
-    public function testExpiresInWithExpiresAt()
+    public function testExpiresInWithExpiresAt(): void
     {
         $token = new Token();
         $token->setExpiresAt(time() + 60);

--- a/Tests/Propel/AuthCodeManagerTest.php
+++ b/Tests/Propel/AuthCodeManagerTest.php
@@ -28,7 +28,7 @@ class AuthCodeManagerTest extends PropelTestCase
 
     protected $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -36,17 +36,17 @@ class AuthCodeManagerTest extends PropelTestCase
         AuthCodeQuery::create()->deleteAll();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertSame(self::AUTH_CODE_CLASS, $this->manager->getClass());
     }
 
-    public function testCreateClass()
+    public function testCreateClass(): void
     {
         $this->assertInstanceOf(self::AUTH_CODE_CLASS, $this->manager->createAuthCode());
     }
 
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $authCode = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\AuthCode')
             ->disableOriginalConstructor()
@@ -60,7 +60,7 @@ class AuthCodeManagerTest extends PropelTestCase
         $this->manager->updateAuthCode($authCode);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $authCode = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\AuthCode')
             ->disableOriginalConstructor()
@@ -74,14 +74,14 @@ class AuthCodeManagerTest extends PropelTestCase
         $this->manager->deleteAuthCode($authCode);
     }
 
-    public function testFindAuthCodeReturnsNullIfNotFound()
+    public function testFindAuthCodeReturnsNullIfNotFound(): void
     {
         $authCode = $this->manager->findAuthCodeBy(['token' => '12345']);
 
         $this->assertNull($authCode);
     }
 
-    public function testFindAuthCode()
+    public function testFindAuthCode(): void
     {
         $authCode = $this->createAuthCode('12345');
         $return = $this->manager->findAuthCodeBy(['token' => '12345']);
@@ -90,7 +90,7 @@ class AuthCodeManagerTest extends PropelTestCase
         $this->assertSame($authCode, $return);
     }
 
-    public function testFindAuthCodeByToken()
+    public function testFindAuthCodeByToken(): void
     {
         $authCode = $this->createAuthCode('12345');
         $return = $this->manager->findAuthCodeByToken('12345');
@@ -99,14 +99,14 @@ class AuthCodeManagerTest extends PropelTestCase
         $this->assertSame($authCode, $return);
     }
 
-    public function testFindAuthCodeByTokenReturnsNullIfNotFound()
+    public function testFindAuthCodeByTokenReturnsNullIfNotFound(): void
     {
         $return = $this->manager->findAuthCodeByToken('12345');
 
         $this->assertNull($return);
     }
 
-    public function testFindAuthCodeWithInvalidData()
+    public function testFindAuthCodeWithInvalidData(): void
     {
         $token = $this->manager->findAuthCodeBy(['foo' => '12345']);
         $this->assertNull($token);
@@ -118,7 +118,7 @@ class AuthCodeManagerTest extends PropelTestCase
         $this->assertNull($token);
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $a1 = $this->createAuthCode('12345', time() + 100);
         $a2 = $this->createAuthCode('67890', time() - 100);

--- a/Tests/Propel/AuthCodeTest.php
+++ b/Tests/Propel/AuthCodeTest.php
@@ -28,7 +28,7 @@ class AuthCodeTest extends PropelTestCase
      * @param mixed $expiresAt
      * @param mixed $expect
      */
-    public function testHasExpired($expiresAt, $expect)
+    public function testHasExpired($expiresAt, $expect): void
     {
         $token = new AuthCode();
         $token->setExpiresAt($expiresAt);
@@ -45,14 +45,14 @@ class AuthCodeTest extends PropelTestCase
         ];
     }
 
-    public function testExpiresIn()
+    public function testExpiresIn(): void
     {
         $token = new AuthCode();
 
         $this->assertSame(PHP_INT_MAX, $token->getExpiresIn());
     }
 
-    public function testExpiresInWithExpiresAt()
+    public function testExpiresInWithExpiresAt(): void
     {
         $token = new AuthCode();
         $token->setExpiresAt(time() + 60);

--- a/Tests/Propel/ClientManagerTest.php
+++ b/Tests/Propel/ClientManagerTest.php
@@ -23,7 +23,7 @@ class ClientManagerTest extends PropelTestCase
 
     protected $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,17 +31,17 @@ class ClientManagerTest extends PropelTestCase
         ClientQuery::create()->deleteAll();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertSame(self::CLIENT_CLASS, $this->manager->getClass());
     }
 
-    public function testCreateClass()
+    public function testCreateClass(): void
     {
         $this->assertInstanceOf(self::CLIENT_CLASS, $this->manager->createClient());
     }
 
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $client = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\Client')
             ->disableOriginalConstructor()
@@ -55,7 +55,7 @@ class ClientManagerTest extends PropelTestCase
         $this->manager->updateClient($client);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $client = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\Client')
             ->disableOriginalConstructor()
@@ -69,14 +69,14 @@ class ClientManagerTest extends PropelTestCase
         $this->manager->deleteClient($client);
     }
 
-    public function testFindClientReturnsNullIfNotFound()
+    public function testFindClientReturnsNullIfNotFound(): void
     {
         $client = $this->manager->findClientBy(['id' => '1', 'randomId' => '2345']);
 
         $this->assertNull($client);
     }
 
-    public function testFindClientWithInvalidCriteria()
+    public function testFindClientWithInvalidCriteria(): void
     {
         $client = $this->manager->findClientBy(['randomId' => '2345']);
         $this->assertNull($client);
@@ -88,7 +88,7 @@ class ClientManagerTest extends PropelTestCase
         $this->assertNull($client);
     }
 
-    public function testFindClient()
+    public function testFindClient(): void
     {
         $client = $this->createClient('2345');
         $return = $this->manager->findClientBy(['id' => '1', 'randomId' => '2345']);
@@ -97,7 +97,7 @@ class ClientManagerTest extends PropelTestCase
         $this->assertSame($client, $return);
     }
 
-    public function testFindClientByPublicId()
+    public function testFindClientByPublicId(): void
     {
         $client = $this->createClient('12345');
         $return = $this->manager->findClientByPublicId('1_12345');
@@ -106,14 +106,14 @@ class ClientManagerTest extends PropelTestCase
         $this->assertSame($client, $return);
     }
 
-    public function testFindClientByPublicIdReturnsNullIfNotFound()
+    public function testFindClientByPublicIdReturnsNullIfNotFound(): void
     {
         $return = $this->manager->findClientByPublicId('1_12345');
 
         $this->assertNull($return);
     }
 
-    public function testFindClientByPublicIdReturnsNullIfInvalidPublicId()
+    public function testFindClientByPublicIdReturnsNullIfInvalidPublicId(): void
     {
         $return = $this->manager->findClientByPublicId('1');
         $this->assertNull($return);

--- a/Tests/Propel/ClientTest.php
+++ b/Tests/Propel/ClientTest.php
@@ -18,7 +18,7 @@ use OAuth2\OAuth2;
 
 class ClientTest extends PropelTestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $client = new Client();
 
@@ -30,7 +30,7 @@ class ClientTest extends PropelTestCase
         $this->assertSame(OAuth2::GRANT_TYPE_AUTH_CODE, $types[0]);
     }
 
-    public function testCheckSecretWithInvalidArgument()
+    public function testCheckSecretWithInvalidArgument(): void
     {
         $client = new Client();
 
@@ -39,7 +39,7 @@ class ClientTest extends PropelTestCase
         $this->assertFalse($client->checkSecret(null));
     }
 
-    public function testCheckSecret()
+    public function testCheckSecret(): void
     {
         $client = new Client();
         $client->setSecret('foo');

--- a/Tests/Propel/PropelTestCase.php
+++ b/Tests/Propel/PropelTestCase.php
@@ -17,7 +17,7 @@ use FOS\OAuthServerBundle\Tests\TestCase;
 
 class PropelTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('\Propel')) {
             $this->markTestSkipped('Propel is not installed.');

--- a/Tests/Propel/TokenManagerTest.php
+++ b/Tests/Propel/TokenManagerTest.php
@@ -28,7 +28,7 @@ class TokenManagerTest extends PropelTestCase
 
     protected $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -36,18 +36,18 @@ class TokenManagerTest extends PropelTestCase
         TokenQuery::create()->deleteAll();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertSame(self::TOKEN_CLASS, $this->manager->getClass());
     }
 
-    public function testCreateClass()
+    public function testCreateClass(): void
     {
         $this->manager = new TokenManager('Token');
         $this->assertInstanceOf('Token', $this->manager->createToken());
     }
 
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $token = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\Token')
             ->disableOriginalConstructor()
@@ -61,7 +61,7 @@ class TokenManagerTest extends PropelTestCase
         $this->manager->updateToken($token);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $token = $this->getMockBuilder('FOS\OAuthServerBundle\Propel\Token')
             ->disableOriginalConstructor()
@@ -75,14 +75,14 @@ class TokenManagerTest extends PropelTestCase
         $this->manager->deleteToken($token);
     }
 
-    public function testFindTokenReturnsNullIfNotFound()
+    public function testFindTokenReturnsNullIfNotFound(): void
     {
         $token = $this->manager->findTokenBy(['token' => '12345']);
 
         $this->assertNull($token);
     }
 
-    public function testFindTokenWithInvalidData()
+    public function testFindTokenWithInvalidData(): void
     {
         $token = $this->manager->findTokenBy(['foo' => '12345']);
         $this->assertNull($token);
@@ -94,7 +94,7 @@ class TokenManagerTest extends PropelTestCase
         $this->assertNull($token);
     }
 
-    public function testFindToken()
+    public function testFindToken(): void
     {
         $token = $this->createToken('12345');
         $return = $this->manager->findTokenBy(['token' => '12345']);
@@ -103,7 +103,7 @@ class TokenManagerTest extends PropelTestCase
         $this->assertSame($token, $return);
     }
 
-    public function testFindTokenByToken()
+    public function testFindTokenByToken(): void
     {
         $token = $this->createToken('12345');
         $return = $this->manager->findTokenByToken('12345');
@@ -112,14 +112,14 @@ class TokenManagerTest extends PropelTestCase
         $this->assertSame($token, $return);
     }
 
-    public function testFindTokenByTokenReturnsNullIfNotFound()
+    public function testFindTokenByTokenReturnsNullIfNotFound(): void
     {
         $return = $this->manager->findTokenByToken('12345');
 
         $this->assertNull($return);
     }
 
-    public function testDeleteExpired()
+    public function testDeleteExpired(): void
     {
         $a1 = $this->createToken('12345', time() + 100);
         $a2 = $this->createToken('67890', time() - 100);

--- a/Tests/Propel/TokenTest.php
+++ b/Tests/Propel/TokenTest.php
@@ -28,7 +28,7 @@ class TokenTest extends PropelTestCase
      * @param mixed $expiresAt
      * @param mixed $expect
      */
-    public function testHasExpired($expiresAt, $expect)
+    public function testHasExpired($expiresAt, $expect): void
     {
         $token = new Token();
         $token->setExpiresAt($expiresAt);
@@ -45,14 +45,14 @@ class TokenTest extends PropelTestCase
         ];
     }
 
-    public function testExpiresIn()
+    public function testExpiresIn(): void
     {
         $token = new Token();
 
         $this->assertSame(PHP_INT_MAX, $token->getExpiresIn());
     }
 
-    public function testExpiresInWithExpiresAt()
+    public function testExpiresInWithExpiresAt(): void
     {
         $token = new Token();
         $token->setExpiresAt(time() + 60);

--- a/Tests/Security/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Authentication/Provider/OAuthProviderTest.php
@@ -24,12 +24,12 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class OAuthProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|UserInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|UserInterface
      */
     protected $user;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|UserProviderInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|UserProviderInterface
      */
     protected $userProvider;
 
@@ -39,7 +39,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
     protected $provider;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|OAuth2
+     * @var \PHPUnit\Framework\MockObject\MockObject|OAuth2
      */
     protected $serverService;
 
@@ -48,7 +48,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
      */
     protected $userChecker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->user = $this->getMockBuilder(UserInterface::class)
             ->disableOriginalConstructor()
@@ -70,7 +70,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
         $this->provider = new OAuthProvider($this->userProvider, $this->serverService, $this->userChecker);
     }
 
-    public function testAuthenticateReturnsTokenIfValid()
+    public function testAuthenticateReturnsTokenIfValid(): void
     {
         $token = new OAuthToken();
         $token->setToken('x');
@@ -99,7 +99,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('ROLE_USER', $roles[0]);
     }
 
-    public function testAuthenticateReturnsTokenIfValidEvenIfNullData()
+    public function testAuthenticateReturnsTokenIfValidEvenIfNullData(): void
     {
         $token = new OAuthToken();
         $token->setToken('x');
@@ -119,7 +119,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $result->getRoleNames());
     }
 
-    public function testAuthenticateTransformsScopesAsRoles()
+    public function testAuthenticateTransformsScopesAsRoles(): void
     {
         $token = new OAuthToken();
         $token->setToken('x');
@@ -144,7 +144,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('ROLE_BAR', $roles[1]);
     }
 
-    public function testAuthenticateWithNullScope()
+    public function testAuthenticateWithNullScope(): void
     {
         $this->markTestIncomplete('Scope is not nullable');
 
@@ -167,7 +167,7 @@ class OAuthProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $result->getRoleNames());
     }
 
-    public function testAuthenticateWithEmptyScope()
+    public function testAuthenticateWithEmptyScope(): void
     {
         $token = new OAuthToken();
         $token->setToken('x');

--- a/Tests/Security/Authentification/Token/OAuthTokenTest.php
+++ b/Tests/Security/Authentification/Token/OAuthTokenTest.php
@@ -23,14 +23,14 @@ class OAuthTokenTest extends \PHPUnit\Framework\TestCase
      */
     protected $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->instance = new OAuthToken();
 
         parent::setUp();
     }
 
-    public function testSetTokenWillSetToken()
+    public function testSetTokenWillSetToken(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -41,7 +41,7 @@ class OAuthTokenTest extends \PHPUnit\Framework\TestCase
         $this->assertAttributeSame($token, 'token', $this->instance);
     }
 
-    public function testGetTokenWillReturnToken()
+    public function testGetTokenWillReturnToken(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()
@@ -53,7 +53,7 @@ class OAuthTokenTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($token, $this->instance->getToken());
     }
 
-    public function testGetCredentialsWillReturnToken()
+    public function testGetCredentialsWillReturnToken(): void
     {
         $token = $this->getMockBuilder(TokenInterface::class)
             ->disableOriginalConstructor()

--- a/Tests/Security/Firewall/OAuthListenerTest.php
+++ b/Tests/Security/Firewall/OAuthListenerTest.php
@@ -31,7 +31,7 @@ class OAuthListenerTest extends TestCase
 
     protected $event;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serverService = $this->getMockBuilder(OAuth2::class)
             ->disableOriginalConstructor()
@@ -64,7 +64,7 @@ class OAuthListenerTest extends TestCase
         ;
     }
 
-    public function testHandle()
+    public function testHandle(): void
     {
         $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
 
@@ -93,7 +93,7 @@ class OAuthListenerTest extends TestCase
         $this->assertSame('a-token', $token->getToken());
     }
 
-    public function testHandleResponse()
+    public function testHandleResponse(): void
     {
         $listener = new OAuthListener($this->securityContext, $this->authManager, $this->serverService);
 

--- a/Tests/Storage/OAuthStorageTest.php
+++ b/Tests/Storage/OAuthStorageTest.php
@@ -43,7 +43,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
 
     protected $storage;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->clientManager = $this->getMockBuilder(ClientManagerInterface::class)
             ->disableOriginalConstructor()
@@ -73,7 +73,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage = new OAuthStorage($this->clientManager, $this->accessTokenManager, $this->refreshTokenManager, $this->authCodeManager, $this->userProvider, $this->encoderFactory);
     }
 
-    public function testGetClientReturnsClientWithGivenId()
+    public function testGetClientReturnsClientWithGivenId(): void
     {
         $client = new Client();
 
@@ -86,7 +86,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($client, $this->storage->getClient('123_abc'));
     }
 
-    public function testGetClientReturnsNullIfNotExists()
+    public function testGetClientReturnsNullIfNotExists(): void
     {
         $client = new Client();
 
@@ -99,7 +99,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->storage->getClient('123_abc'));
     }
 
-    public function testCheckClientCredentialsThrowsIfInvalidClientClass()
+    public function testCheckClientCredentialsThrowsIfInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -110,7 +110,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->checkClientCredentials($client, 'dummy');
     }
 
-    public function testCheckClientCredentialsReturnsTrueOnValidCredentials()
+    public function testCheckClientCredentialsReturnsTrueOnValidCredentials(): void
     {
         $client = new Client();
         $client->setSecret('dummy');
@@ -118,7 +118,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->storage->checkClientCredentials($client, 'dummy'));
     }
 
-    public function testCheckClientCredentialsReturnsFalseOnValidCredentials()
+    public function testCheckClientCredentialsReturnsFalseOnValidCredentials(): void
     {
         $client = new Client();
         $client->setSecret('dummy');
@@ -126,7 +126,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->storage->checkClientCredentials($client, 'passe'));
     }
 
-    public function testGetAccessTokenReturnsAccessTokenWithGivenId()
+    public function testGetAccessTokenReturnsAccessTokenWithGivenId(): void
     {
         $token = new AccessToken();
 
@@ -139,7 +139,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($token, $this->storage->getAccessToken('123_abc'));
     }
 
-    public function testGetAccessTokenReturnsNullIfNotExists()
+    public function testGetAccessTokenReturnsNullIfNotExists(): void
     {
         $token = new AccessToken();
 
@@ -152,7 +152,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->storage->getAccessToken('123_abc'));
     }
 
-    public function testCreateAccessTokenThrowsOnInvalidClientClass()
+    public function testCreateAccessTokenThrowsOnInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -163,7 +163,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->createAccessToken('foo', $client, new User(42), 1, 'foo bar');
     }
 
-    public function testCreateAccessToken()
+    public function testCreateAccessToken(): void
     {
         $savedToken = null;
 
@@ -194,7 +194,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('foo bar', $token->getScope());
     }
 
-    public function testCreateAccessTokenWithoutUser()
+    public function testCreateAccessTokenWithoutUser(): void
     {
         $savedToken = null;
 
@@ -218,7 +218,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($token, $savedToken);
     }
 
-    public function testGetRefreshTokenReturnsRefreshTokenWithGivenId()
+    public function testGetRefreshTokenReturnsRefreshTokenWithGivenId(): void
     {
         $token = new RefreshToken();
 
@@ -231,7 +231,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($token, $this->storage->getRefreshToken('123_abc'));
     }
 
-    public function testGetRefreshTokenReturnsNullIfNotExists()
+    public function testGetRefreshTokenReturnsNullIfNotExists(): void
     {
         $this->refreshTokenManager->expects($this->once())
             ->method('findTokenByToken')
@@ -242,7 +242,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->storage->getRefreshToken('123_abc'));
     }
 
-    public function testCreateRefreshTokenThrowsOnInvalidClientClass()
+    public function testCreateRefreshTokenThrowsOnInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -253,7 +253,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->createRefreshToken('foo', $client, 42, 1, 'foo bar');
     }
 
-    public function testCreateRefreshToken()
+    public function testCreateRefreshToken(): void
     {
         $savedToken = null;
 
@@ -284,7 +284,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('foo bar', $token->getScope());
     }
 
-    public function testCreateRefreshTokenWithoutUser()
+    public function testCreateRefreshTokenWithoutUser(): void
     {
         $savedToken = null;
 
@@ -308,7 +308,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($token, $savedToken);
     }
 
-    public function testCheckRestrictedGrantTypeThrowsOnInvalidClientClass()
+    public function testCheckRestrictedGrantTypeThrowsOnInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -320,7 +320,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->checkRestrictedGrantType($client, 'foo');
     }
 
-    public function testCheckRestrictedGrantType()
+    public function testCheckRestrictedGrantType(): void
     {
         $client = new Client();
         $client->setAllowedGrantTypes(['foo', 'bar']);
@@ -330,7 +330,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->storage->checkRestrictedGrantType($client, 'baz'));
     }
 
-    public function testCheckUserCredentialsThrowsOnInvalidClientClass()
+    public function testCheckUserCredentialsThrowsOnInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -342,7 +342,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->checkUserCredentials($client, 'Joe', 'baz');
     }
 
-    public function testCheckUserCredentialsCatchesAuthenticationExceptions()
+    public function testCheckUserCredentialsCatchesAuthenticationExceptions(): void
     {
         $client = new Client();
 
@@ -358,7 +358,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result);
     }
 
-    public function testCheckUserCredentialsReturnsTrueOnValidCredentials()
+    public function testCheckUserCredentialsReturnsTrueOnValidCredentials(): void
     {
         $client = new Client();
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
@@ -397,7 +397,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         ], $this->storage->checkUserCredentials($client, 'Joe', 'baz'));
     }
 
-    public function testCheckUserCredentialsReturnsFalseOnInvalidCredentials()
+    public function testCheckUserCredentialsReturnsFalseOnInvalidCredentials(): void
     {
         $client = new Client();
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')
@@ -434,7 +434,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->storage->checkUserCredentials($client, 'Joe', 'baz'));
     }
 
-    public function testCheckUserCredentialsReturnsFalseIfUserNotExist()
+    public function testCheckUserCredentialsReturnsFalseIfUserNotExist(): void
     {
         $client = new Client();
 
@@ -447,7 +447,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->storage->checkUserCredentials($client, 'Joe', 'baz'));
     }
 
-    public function testCreateAuthCodeThrowsOnInvalidClientClass()
+    public function testCreateAuthCodeThrowsOnInvalidClientClass(): void
     {
         $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
             ->disableOriginalConstructor()
@@ -458,7 +458,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->createAuthCode('foo', $client, 42, 'http://www.example.com/', 1, 'foo bar');
     }
 
-    public function testCreateAuthCode()
+    public function testCreateAuthCode(): void
     {
         $savedCode = null;
 
@@ -489,7 +489,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('foo bar', $code->getScope());
     }
 
-    public function testGetAuthCodeReturnsAuthCodeWithGivenId()
+    public function testGetAuthCodeReturnsAuthCodeWithGivenId(): void
     {
         $code = new AuthCode();
 
@@ -502,7 +502,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($code, $this->storage->getAuthCode('123_abc'));
     }
 
-    public function testGetAuthCodeReturnsNullIfNotExists()
+    public function testGetAuthCodeReturnsNullIfNotExists(): void
     {
         $this->authCodeManager->expects($this->once())
             ->method('findAuthCodeByToken')
@@ -513,7 +513,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->storage->getAuthCode('123_abc'));
     }
 
-    public function testValidGrantExtension()
+    public function testValidGrantExtension(): void
     {
         $grantExtension = $this->getMockBuilder('FOS\OAuthServerBundle\Storage\GrantExtensionInterface')
             ->disableOriginalConstructor()
@@ -533,7 +533,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->storage->checkGrantExtension($client, 'https://friendsofsymfony.com/grants/foo', [], []));
     }
 
-    public function testInvalidGrantExtension()
+    public function testInvalidGrantExtension(): void
     {
         $this->expectException(\OAuth2\OAuth2ServerException::class);
 
@@ -544,7 +544,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->checkGrantExtension($client, 'https://friendsofsymfony.com/grants/bar', [], []);
     }
 
-    public function testDoubleSetGrantExtension()
+    public function testDoubleSetGrantExtension(): void
     {
         $grantExtension = $this->getMockBuilder('FOS\OAuthServerBundle\Storage\GrantExtensionInterface')
             ->disableOriginalConstructor()
@@ -565,7 +565,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($grantExtension2, $grantExtensions[$uri]);
     }
 
-    public function testMarkAuthCodeAsUsedIfAuthCodeFound()
+    public function testMarkAuthCodeAsUsedIfAuthCodeFound(): void
     {
         $authCode = $this->getMockBuilder('FOS\OAuthServerBundle\Model\AuthCodeInterface')
             ->disableOriginalConstructor()
@@ -587,7 +587,7 @@ class OAuthStorageTest extends \PHPUnit\Framework\TestCase
         $this->storage->markAuthCodeAsUsed('123_abc');
     }
 
-    public function testMarkAuthCodeAsUsedIfAuthCodeNotFound()
+    public function testMarkAuthCodeAsUsedIfAuthCodeNotFound(): void
     {
         $this->authCodeManager->expects($this->atLeastOnce())
             ->method('findAuthCodeByToken')

--- a/Tests/Util/RandomTest.php
+++ b/Tests/Util/RandomTest.php
@@ -25,7 +25,7 @@ class RandomTest extends \PHPUnit\Framework\TestCase
 {
     use PHPMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -33,7 +33,7 @@ class RandomTest extends \PHPUnit\Framework\TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testGenerateTokenWillUseRandomBytesIfAvailable()
+    public function testGenerateTokenWillUseRandomBytesIfAvailable(): void
     {
         $hashResult = \random_bytes(32);
 


### PR DESCRIPTION
This commit was carried out by the command:
```bash
sed -i '
s/function test[A-Za-z0-9]*(.*)$/\0: void/
s/function setUp()$/\0: void/
s/PHPUnit_Framework_MockObject_MockObject/PHPUnit\\Framework\\MockObject\\MockObject/
' $(find Tests/ -type f)
```
alone so should be fairly straightforward to review. (Rough) subset of #663 as requested there.
