### PR TITLE
Added default names in the commands for lazy loading

### DIFF
--- a/Command/CleanCommand.php
+++ b/Command/CleanCommand.php
@@ -21,7 +21,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanCommand extends Command
 {
-
     protected static $defaultName = 'fos:oauth-server:clean';
 
     private $accessTokenManager;
@@ -31,8 +30,8 @@ class CleanCommand extends Command
     public function __construct(
         TokenManagerInterface $accessTokenManager,
         TokenManagerInterface $refreshTokenManager,
-        AuthCodeManagerInterface $authCodeManager)
-    {
+        AuthCodeManagerInterface $authCodeManager
+    ) {
         parent::__construct();
 
         $this->accessTokenManager = $accessTokenManager;

--- a/Command/CleanCommand.php
+++ b/Command/CleanCommand.php
@@ -47,7 +47,6 @@ class CleanCommand extends Command
         parent::configure();
 
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Clean expired tokens')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command will remove expired OAuth2 tokens.

--- a/Command/CleanCommand.php
+++ b/Command/CleanCommand.php
@@ -21,6 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanCommand extends Command
 {
+
+    protected static $defaultName = 'fos:oauth-server:clean';
+
     private $accessTokenManager;
     private $refreshTokenManager;
     private $authCodeManager;
@@ -45,7 +48,7 @@ class CleanCommand extends Command
         parent::configure();
 
         $this
-            ->setName('fos:oauth-server:clean')
+            ->setName(self::$defaultName)
             ->setDescription('Clean expired tokens')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command will remove expired OAuth2 tokens.

--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CreateClientCommand extends Command
 {
+    protected static $defaultName = 'fos:oauth-server:create-client';
+
     private $clientManager;
 
     public function __construct(ClientManagerInterface $clientManager)
@@ -39,7 +41,7 @@ class CreateClientCommand extends Command
         parent::configure();
 
         $this
-            ->setName('fos:oauth-server:create-client')
+            ->setName(self::$defaultName)
             ->setDescription('Creates a new client')
             ->addOption(
                 'redirect-uri',

--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -41,7 +41,6 @@ class CreateClientCommand extends Command
         parent::configure();
 
         $this
-            ->setName(self::$defaultName)
             ->setDescription('Creates a new client')
             ->addOption(
                 'redirect-uri',


### PR DESCRIPTION
We are using the OAuth server bundle in a large application and we have noticed that the commands are always loaded when called from the console. So we would be happy if the change is accepted.

See documentation for lazy loading: https://symfony.com/doc/current/console/commands_as_services.html#lazy-loading
There are no negative effects.