### PR TITLE
Re-add templating engine

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -16,7 +16,8 @@ This changelog references the relevant changes done in 6.0 versions.
 * **[BC break]** Removed class `FOS\OAuthServerBundle\Event\OAuthEvent`, use dedicated event classes instead: [[#655](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/655)]
     - `OAuthEvent::PRE_AUTHORIZATION_PROCESS` => `FOS\OAuthServerBundle\Event\PreAuthorizationEvent`
     - `OAuthEvent::POST_AUTHORIZATION_PROCESS` => `FOS\OAuthServerBundle\Event\PostAuthorizationEvent`
-* **[BC break]** Removed support for templating engine [[#653](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/653)]
+* **[BC break]** Removed support for templating engine [[#653](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/653)] 
+  * **NOTE: We added this back just for Mautic 4**
 
 ### 2.0.0-ALPHA0 (2018-05-01)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -16,8 +16,6 @@ This changelog references the relevant changes done in 6.0 versions.
 * **[BC break]** Removed class `FOS\OAuthServerBundle\Event\OAuthEvent`, use dedicated event classes instead: [[#655](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/655)]
     - `OAuthEvent::PRE_AUTHORIZATION_PROCESS` => `FOS\OAuthServerBundle\Event\PreAuthorizationEvent`
     - `OAuthEvent::POST_AUTHORIZATION_PROCESS` => `FOS\OAuthServerBundle\Event\PostAuthorizationEvent`
-* **[BC break]** Removed support for templating engine [[#653](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/653)] 
-  * **NOTE: We added this back just for Mautic 4**
 
 ### 2.0.0-ALPHA0 (2018-05-01)
 

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -20,6 +20,7 @@ use FOS\OAuthServerBundle\Model\ClientInterface;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use OAuth2\OAuth2;
 use OAuth2\OAuth2ServerException;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,7 +32,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Twig\Environment as TwigEnvironment;
 
 /**
  * Controller handling basic authorization.
@@ -66,6 +66,11 @@ class AuthorizeController
     private $oAuth2Server;
 
     /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -76,11 +81,6 @@ class AuthorizeController
     private $tokenStorage;
 
     /**
-     * @var TwigEnvironment
-     */
-    private $twig;
-
-    /**
      * @var UrlGeneratorInterface
      */
     private $router;
@@ -89,6 +89,11 @@ class AuthorizeController
      * @var ClientManagerInterface
      */
     private $clientManager;
+
+    /**
+     * @var string
+     */
+    private $templateEngineType;
 
     /**
      * @var EventDispatcherInterface
@@ -102,29 +107,32 @@ class AuthorizeController
      * @todo This controller could be refactored to not rely on so many dependencies
      *
      * @param SessionInterface $session
+     * @param string           $templateEngineType
      */
     public function __construct(
         RequestStack $requestStack,
         Form $authorizeForm,
         AuthorizeFormHandler $authorizeFormHandler,
         OAuth2 $oAuth2Server,
+        EngineInterface $templating,
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $router,
         ClientManagerInterface $clientManager,
         EventDispatcherInterface $eventDispatcher,
-        TwigEnvironment $twig,
-        SessionInterface $session = null
+        SessionInterface $session = null,
+        $templateEngineType = 'twig'
     ) {
         $this->requestStack = $requestStack;
         $this->session = $session;
         $this->authorizeForm = $authorizeForm;
         $this->authorizeFormHandler = $authorizeFormHandler;
         $this->oAuth2Server = $oAuth2Server;
+        $this->templating = $templating;
         $this->tokenStorage = $tokenStorage;
         $this->router = $router;
         $this->clientManager = $clientManager;
+        $this->templateEngineType = $templateEngineType;
         $this->eventDispatcher = $eventDispatcher;
-        $this->twig = $twig;
     }
 
     /**
@@ -159,10 +167,12 @@ class AuthorizeController
             return $this->processSuccess($user, $formHandler, $request);
         }
 
-        return $this->renderAuthorize([
+        $data = [
             'form' => $form->createView(),
             'client' => $this->getClient(),
-        ]);
+        ];
+
+        return $this->renderAuthorize($data, $this->templating, $this->templateEngineType);
     }
 
     /**
@@ -202,7 +212,7 @@ class AuthorizeController
     }
 
     /**
-     * @return ClientInterface
+     * @return ClientInterface
      */
     protected function getClient()
     {
@@ -228,10 +238,14 @@ class AuthorizeController
         return $this->client;
     }
 
-    protected function renderAuthorize(array $context): Response
+    /**
+     * @throws \RuntimeException
+     */
+    protected function renderAuthorize(array $data, EngineInterface $engine, string $engineType): Response
     {
-        return new Response(
-            $this->twig->render('@FOSOAuthServer/Authorize/authorize.html.twig', $context)
+        return $engine->renderResponse(
+            '@FOSOAuthServer/Authorize/authorize.html.'.$engineType,
+            $data
         );
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,6 +79,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addAuthorizeSection($rootNode);
         $this->addServiceSection($rootNode);
+        $this->addTemplateSection($rootNode);
 
         return $treeBuilder;
     }
@@ -129,6 +130,20 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('variable')->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addTemplateSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('template')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('engine')->defaultValue('twig')->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/FOSOAuthServerExtension.php
+++ b/DependencyInjection/FOSOAuthServerExtension.php
@@ -68,6 +68,7 @@ class FOSOAuthServerExtension extends Extension
                 'refresh_token_class' => 'fos_oauth_server.model.refresh_token.class',
                 'auth_code_class' => 'fos_oauth_server.model.auth_code.class',
             ],
+            'template' => 'fos_oauth_server.template.%s',
         ]);
 
         // Handle the MongoDB document manager name in a specific way as it does not have a registry to make it easy

--- a/Resources/config/authorize.xml
+++ b/Resources/config/authorize.xml
@@ -28,12 +28,13 @@
             <argument type="service" id="fos_oauth_server.authorize.form" />
             <argument type="service" id="fos_oauth_server.authorize.form.handler" />
             <argument type="service" id="fos_oauth_server.server" />
+            <argument type="service" id="templating" />
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="router" />
             <argument type="service" id="fos_oauth_server.client_manager" />
             <argument type="service" id="event_dispatcher" />
-            <argument type="service" id="twig" />
             <argument type="service" id="session" on-invalid="null" />
+            <argument>%fos_oauth_server.template.engine%</argument>
         </service>
     </services>
 

--- a/Tests/Functional/config/config.yml
+++ b/Tests/Functional/config/config.yml
@@ -1,12 +1,10 @@
 framework:
+    templating:
+        engines: ["twig"]
     form: ~
     secret: test
     router:
         resource: '%kernel.project_dir%/Tests/Functional/config/routing.yml'
-
-twig:
-    exception_controller: null
-    strict_variables: '%kernel.debug%'
 
 fos_oauth_server:
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/dependency-injection": "^4.4 || ^5.1",
         "symfony/framework-bundle": "^4.4 || ^5.1",
-        "symfony/security-bundle": "^4.4 || ^5.1",
-        "symfony/twig-bundle": "^4.4 || ^5.1"
+        "symfony/security-bundle": "^4.4 || ^5.1"
     },
     "conflict": {
         "twig/twig": "<1.40 || >=2.0,<2.9"
@@ -43,6 +42,8 @@
         "symfony/console": "^4.4 || ^5.1",
         "symfony/form": "^4.4 || ^5.1",
         "symfony/phpunit-bridge": "^4.4 || ^5.1",
+        "symfony/templating": "^4.4 || ^5.1",
+        "symfony/twig-bundle": "^4.4 || ^5.1",
         "symfony/yaml": "^4.4 || ^5.1",
         "willdurand/propel-typehintable-behavior": "~1.0"
     },


### PR DESCRIPTION
In #653, the templating engine was removed in favor of Twig. PHP templates [have been deprecated](https://symfony.com/doc/4.4/templating/PHP.html) in Symfony 4.3 and removed in Symfony 5.

However, in https://github.com/mautic/mautic we still heavily rely on PHP templates and are not ready to move to Twig templates just yet, as there's a lot of technical debt involved. Symfony 4.4 [will be supported](https://symfony.com/releases/4.4) until November 2022 and will receive security fixes until November 2023. Would you please consider re-adding the template engine for now? Otherwise we can't get PHP 8.0 support to Mautic as soon as you release v2 of this bundle.

Thanks in advance!