### PR TITLE
Simplify OAuthEventClass documentation

### DIFF
--- a/Resources/doc/the_oauth_event_class.md
+++ b/Resources/doc/the_oauth_event_class.md
@@ -39,11 +39,9 @@ class OAuthEventListener
     public function onPostAuthorization(PostAuthorizationEvent $event)
     {
         if ($event->isAuthorizedClient()) {
-            if (null !== $client = $event->getClient()) {
-                $user = $this->getUser($event);
-                $user->addClient($client);
-                $user->save();
-            }
+            $user = $this->getUser($event);
+            $user->addClient($event->getClient());
+            $user->save();
         }
     }
 


### PR DESCRIPTION
As the `$event->getClient()` method [returns a ClientInterface](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/blob/master/Event/AbstractAuthorizationEvent.php#L59), there is no need to check that this value is not null