### PR TITLE
Removed deprecated fieldName attributes from ODM definition

### DIFF
--- a/Resources/config/doctrine/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/AccessToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AccessToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/AccessToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AccessToken">
-        <field name="token" field-name="token" type="string" unique="true" />
-        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
-        <field name="scope" field-name="scope" type="string" nullable="true" />
+        <field name="token" type="string" unique="true" />
+        <field name="expiresAt" type="int" nullable="true" />
+        <field name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/AuthCode.mongodb.xml
+++ b/Resources/config/doctrine/AuthCode.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AuthCode">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="redirectUri" fieldName="redirectUri" type="string" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="redirectUri" field-name="redirectUri" type="string" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/AuthCode.mongodb.xml
+++ b/Resources/config/doctrine/AuthCode.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AuthCode">
-        <field name="token" field-name="token" type="string" unique="true" />
-        <field name="redirectUri" field-name="redirectUri" type="string" />
-        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
-        <field name="scope" field-name="scope" type="string" nullable="true" />
+        <field name="token" type="string" unique="true" />
+        <field name="redirectUri" type="string" />
+        <field name="expiresAt" type="int" nullable="true" />
+        <field name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\Client">
-        <field name="randomId" fieldName="randomId" type="string" />
-        <field name="redirectUris" fieldName="redirectUris" type="collection" />
-        <field name="secret" fieldName="secret" type="string" />
-        <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="collection" />
+        <field name="randomId" field-name="randomId" type="string" />
+        <field name="redirectUris" field-name="redirectUris" type="collection" />
+        <field name="secret" field-name="secret" type="string" />
+        <field name="allowedGrantTypes" field-name="allowedGrantTypes" type="collection" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\Client">
-        <field name="randomId" field-name="randomId" type="string" />
-        <field name="redirectUris" field-name="redirectUris" type="collection" />
-        <field name="secret" field-name="secret" type="string" />
-        <field name="allowedGrantTypes" field-name="allowedGrantTypes" type="collection" />
+        <field name="randomId" type="string" />
+        <field name="redirectUris" type="collection" />
+        <field name="secret" type="string" />
+        <field name="allowedGrantTypes" type="collection" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\RefreshToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field name="token" field-name="token" type="string" unique="true" />
+        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
+        <field name="scope" field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\RefreshToken">
-        <field name="token" field-name="token" type="string" unique="true" />
-        <field name="expiresAt" field-name="expiresAt" type="int" nullable="true" />
-        <field name="scope" field-name="scope" type="string" nullable="true" />
+        <field name="token" type="string" unique="true" />
+        <field name="expiresAt" type="int" nullable="true" />
+        <field name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>


### PR DESCRIPTION
To fixed below issue updated xml files.
`
In MappingException.php line 236:
!!                                                                                 
!!    The mapping file /Users/evert/Sites/mei-api/vendor/friendsofsymfony/oauth-s  
!!    erver-bundle/Resources/config/doctrine/Client.mongodb.xml is invalid:        
!!    Line 8:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo-  
!!    mapping}field', attribute 'fieldName': The attribute 'fieldName' is not all  
!!    owed.                                                                        
!!                                                                                 
!!    Line 9:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo-  
!!    mapping}field', attribute 'fieldName': The attribute 'fieldName' is not all  
!!    owed.                                                                        
!!                                                                                 
!!    Line 10:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo  
!!    -mapping}field', attribute 'fieldName': The attribute 'fieldName' is not al  
!!    lowed.                                                                       
!!                                                                                 
!!    Line 11:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo  
!!    -mapping}field', attribute 'fieldName': The attribute 'fieldName' is not al  
!!    lowed. 
`